### PR TITLE
feat: animated number for slider component

### DIFF
--- a/src/component/v2/forms.tsx
+++ b/src/component/v2/forms.tsx
@@ -131,8 +131,10 @@ export const SettingPasswordVertical: FC<{
 
 // --- Slider/Range Components ---
 
+const springConfig = { mass: 0.8, stiffness: 75, damping: 15 };
+
 const AnimatedNumber = ({ value }: { value: number }) => {
-    const spring = useSpring(value, { mass: 0.8, stiffness: 75, damping: 15 });
+    const spring = useSpring(value, springConfig);
     const display = useTransform(spring, (current) => Math.round(current).toLocaleString());
 
     useEffect(() => {

--- a/src/component/v2/forms.tsx
+++ b/src/component/v2/forms.tsx
@@ -2,7 +2,7 @@
 
 import * as SliderPrimitive from '@radix-ui/react-slider';
 import { clsx } from 'clsx';
-import { motion } from 'motion/react';
+import { motion, useSpring, useTransform } from 'motion/react';
 import { CircleAlert, Eye, EyeOff } from 'lucide-react';
 import React, { FC, useEffect, useId, useState } from 'react';
 import { Button } from './button';
@@ -131,6 +131,17 @@ export const SettingPasswordVertical: FC<{
 
 // --- Slider/Range Components ---
 
+const AnimatedNumber = ({ value }: { value: number }) => {
+    const spring = useSpring(value, { mass: 0.8, stiffness: 75, damping: 15 });
+    const display = useTransform(spring, (current) => Math.round(current).toLocaleString());
+
+    useEffect(() => {
+        spring.set(value);
+    }, [spring, value]);
+
+    return <motion.span>{display}</motion.span>;
+};
+
 export const SettingRangeVertical: FC<{
     label: string;
     value: number;
@@ -146,7 +157,7 @@ export const SettingRangeVertical: FC<{
             <div className="flex justify-between items-center mb-1">
                 <SettingLabel className="mb-0 font-medium">{label}</SettingLabel>
                 <div className="text-blue-500 font-bold font-mono text-sm bg-blue-500/10 px-2 py-1 rounded">
-                    {value.toLocaleString()} {unit}
+                    <AnimatedNumber value={value} /> {unit}
                 </div>
             </div>
 


### PR DESCRIPTION
This PR updates the `SettingRangeVertical` component to include an animated number display, similar to the "Radix Slider with AnimateNumber" example. It uses `motion/react` hooks (`useSpring`, `useTransform`) to animate the value as it changes.

The changes include:
- Importing `useSpring` and `useTransform` from `motion/react`.
- Creating a reusable `AnimatedNumber` component.
- Replacing the static value display in `SettingRangeVertical` with `AnimatedNumber`.

Verified by creating a temporary test component and inspecting the rendered output.

---
*PR created automatically by Jules for task [11582639595785500662](https://jules.google.com/task/11582639595785500662) started by @Asutorufa*