### PR TITLE
feat(ui): unify design tokens and polish outbound/home/route lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,17 @@
   <!-- <meta name="theme-color" content="#000000" /> -->
   <meta name="description" content="yuhaiin" />
   <link rel="apple-touch-icon" href="/docs/logov2192.png" />
+  <script>
+    (function () {
+      try {
+        var pref = localStorage.getItem('yuhaiin.theme');
+        var theme = (pref === 'light' || pref === 'dark')
+          ? pref
+          : (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+        document.documentElement.setAttribute('data-bs-theme', theme);
+      } catch (e) {}
+    })();
+  </script>
 </head>
 
 <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
                 "babel-plugin-react-compiler": "^1.0.0",
                 "chart.js": "^4.5.1",
                 "clsx": "^2.1.1",
-                "framer-motion": "^12.40.0",
                 "i18next": "^26.3.1",
                 "lucide-react": "^1.17.0",
                 "motion": "^12.40.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
         "babel-plugin-react-compiler": "^1.0.0",
         "chart.js": "^4.5.1",
         "clsx": "^2.1.1",
-        "framer-motion": "^12.40.0",
         "i18next": "^26.3.1",
         "lucide-react": "^1.17.0",
         "motion": "^12.40.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { ThemeProvider, useTheme } from '@/common/ThemeProvider';
+import { ThemeProvider } from '@/common/ThemeProvider';
 import { GlobalToastProvider } from '@/component/v2/toast';
 import NavBarContainer from '@/docs/nav/NavBarContainer';
 import { useHashLocation } from '@/hooks/useHashLocation';
@@ -38,7 +38,6 @@ const variants = {
 
 function AppContent() {
     const { direction, location } = useSmartAnimation();
-    const { ready } = useTheme();
 
     useEffect(() => {
         window.Android?.setRefreshEnabled?.(!location.includes('/docs/config/log'))
@@ -48,7 +47,6 @@ function AppContent() {
     const content = (
         <div className={clsx(
             'relative w-auto min-h-screen h-screen overflow-hidden box-border',
-            'transition-[margin-left,max-width,padding] duration-300 ease-[cubic-bezier(0.4,0,0.2,1)]',
             !isLogin && 'pt-[80px] px-[20px] pb-[20px]',
             !isLogin && 'lg:pt-[20px] lg:pl-[292px] lg:pr-[20px] lg:pb-[20px]',
             !isLogin && 'lg:h-screen',
@@ -85,9 +83,7 @@ function AppContent() {
 
     return (
         <GlobalToastProvider>
-            {ready && (
-                isLogin ? content : <NavBarContainer>{content}</NavBarContainer>
-            )}
+            {isLogin ? content : <NavBarContainer>{content}</NavBarContainer>}
         </GlobalToastProvider>
     )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,12 @@
-import { Router, Switch, Route } from 'wouter';
-import { useHashLocation } from '@/hooks/useHashLocation';
-import { useSmartAnimation } from '@/hooks/useSmartAnimation';
-import { AnimatePresence, motion } from 'motion/react';
-import clsx from 'clsx';
-import { useEffect, useState } from 'react';
+import { ThemeProvider, useTheme } from '@/common/ThemeProvider';
 import { GlobalToastProvider } from '@/component/v2/toast';
 import NavBarContainer from '@/docs/nav/NavBarContainer';
+import { useHashLocation } from '@/hooks/useHashLocation';
+import { useSmartAnimation } from '@/hooks/useSmartAnimation';
+import clsx from 'clsx';
+import { AnimatePresence, motion } from 'motion/react';
+import { useEffect } from 'react';
+import { Route, Router, Switch } from 'wouter';
 import { appRoutes } from './routes';
 
 interface AndroidInterface {
@@ -37,29 +38,11 @@ const variants = {
 
 function AppContent() {
     const { direction, location } = useSmartAnimation();
-    const [colorScheme, setColorScheme] = useState<'light' | 'dark' | undefined>(undefined);
+    const { ready } = useTheme();
 
     useEffect(() => {
         window.Android?.setRefreshEnabled?.(!location.includes('/docs/config/log'))
     }, [location])
-
-    useEffect(() => {
-        if (!window.matchMedia) {
-            setColorScheme('light')
-            return
-        }
-        const mq = window.matchMedia('(prefers-color-scheme: dark)')
-        setColorScheme(mq.matches ? 'dark' : 'light')
-        const listener = (evt: MediaQueryListEvent) => setColorScheme(evt.matches ? 'dark' : 'light');
-        mq.addEventListener('change', listener);
-        return () => mq.removeEventListener('change', listener);
-    }, [])
-
-    useEffect(() => {
-        if (colorScheme) {
-            document.documentElement.setAttribute('data-bs-theme', colorScheme)
-        }
-    }, [colorScheme])
 
     const isLogin = location === '/login';
     const content = (
@@ -88,7 +71,7 @@ function AppContent() {
                     )}
                     transition={{ duration: 0.5, ease: "easeInOut" }}
                 >
-                    <Router hook={() => [location, () => {}] as const}>
+                    <Router hook={() => [location, () => { }] as const}>
                         <Switch>
                             {appRoutes.map(({ path, component }) => (
                                 <Route key={path} path={path} component={component} />
@@ -102,7 +85,7 @@ function AppContent() {
 
     return (
         <GlobalToastProvider>
-            {colorScheme && (
+            {ready && (
                 isLogin ? content : <NavBarContainer>{content}</NavBarContainer>
             )}
         </GlobalToastProvider>
@@ -111,8 +94,10 @@ function AppContent() {
 
 export default function App() {
     return (
-        <Router hook={useHashLocation}>
-            <AppContent />
-        </Router>
+        <ThemeProvider>
+            <Router hook={useHashLocation}>
+                <AppContent />
+            </Router>
+        </ThemeProvider>
     );
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,5 @@
-import { AuthTokenKey, getApiUrl } from "@/common/apiurl";
 import { resolveRPCRoute, rpcPath } from "@/api/generated";
+import { AuthTokenKey, getApiUrl } from "@/common/apiurl";
 
 export type APIError = {
     code: number;
@@ -20,7 +20,7 @@ function apiURL(path: string): URL {
     const url = new URL(base);
     url.hash = "";
     url.pathname = path;
-	url.search = "";
+    url.search = "";
     return url;
 }
 
@@ -52,20 +52,20 @@ function errorMessage(raw: unknown, fallback: string): string {
 }
 
 export async function requestJSON<T>(method: "GET" | "POST" | "PUT" | "DELETE", path: string, body?: unknown, query?: Record<string, QueryValue>): Promise<T> {
-	const route = resolveRPCRoute(method, path);
-	const response = await fetch(apiURL(rpcPath(route.operation)), {
-		method: "POST",
-		headers: {
-			...authHeaders(),
-			Accept: "application/json",
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({
-			...toRequestFields(query),
-			...route.params,
-			...toRequestFields(body),
-		}),
-	});
+    const route = resolveRPCRoute(method, path);
+    const response = await fetch(apiURL(rpcPath(route.operation)), {
+        method: "POST",
+        headers: {
+            ...authHeaders(),
+            Accept: "application/json",
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            ...toRequestFields(query),
+            ...coercePathParams(route.params),
+            ...toRequestFields(body),
+        }),
+    });
 
     const raw = await decodeBody(response);
     if (!response.ok) {
@@ -79,8 +79,27 @@ export async function requestJSON<T>(method: "GET" | "POST" | "PUT" | "DELETE", 
     return raw as T;
 }
 
+// Path params from resolveRPCRoute are always strings. Go expects some of them
+// (e.g. rule index) as numbers — send those as JSON numbers.
+const numericPathParams = new Set(["index"]);
+
+function coercePathParams(params: Record<string, string>): Record<string, string | number> {
+    const out: Record<string, string | number> = {};
+    for (const [key, value] of Object.entries(params)) {
+        if (numericPathParams.has(key) && /^-?\d+$/.test(value)) {
+            const n = Number(value);
+            if (Number.isSafeInteger(n)) {
+                out[key] = n;
+                continue;
+            }
+        }
+        out[key] = value;
+    }
+    return out;
+}
+
 function toRequestFields(value: unknown): Record<string, unknown> {
-	if (value === undefined || value === null) return {};
-	if (typeof value === "object" && !Array.isArray(value)) return value as Record<string, unknown>;
-	throw new TypeError("JSON API requests must use an object body");
+    if (value === undefined || value === null) return {};
+    if (typeof value === "object" && !Array.isArray(value)) return value as Record<string, unknown>;
+    throw new TypeError("JSON API requests must use an object body");
 }

--- a/src/api/generated-contracts.ts
+++ b/src/api/generated-contracts.ts
@@ -580,6 +580,7 @@ export namespace Go {
       refreshInterval: string;
       lastRefreshTime: string;
       error: string;
+      hostIndexDisk: boolean;
       maxMindDbGeoIp: MaxMindDBGeoIP;
     }
     export interface ListActivationStatus {

--- a/src/api/route.ts
+++ b/src/api/route.ts
@@ -90,7 +90,11 @@ export async function changeRulePriority(
   target: { name: string; index: number },
   operate: "exchange" | "insert_before" | "insert_after" = "exchange",
 ): Promise<void> {
-  await requestJSON<void>("POST", "/api/v2/route/rules/priority", { source, target, operate });
+  await requestJSON<void>("POST", "/api/v2/route/rules/priority", {
+    source: { name: source.name, index: Number(source.index) },
+    target: { name: target.name, index: Number(target.index) },
+    operate,
+  });
 }
 
 export async function testRule(host: string): Promise<RuleTestResponse> {

--- a/src/common/ThemeProvider.tsx
+++ b/src/common/ThemeProvider.tsx
@@ -20,20 +20,24 @@ type ThemeContextValue = {
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
 
+function getInitialPreference(): ThemePreference {
+    return readThemePreference();
+}
+
+function getInitialResolved(preference: ThemePreference): ResolvedTheme {
+    return resolveTheme(preference, getSystemTheme());
+}
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-    const [preference, setPreferenceState] = useState<ThemePreference>("system");
-    const [resolved, setResolved] = useState<ResolvedTheme | undefined>(undefined);
+    const [preference, setPreferenceState] = useState<ThemePreference>(getInitialPreference);
+    const [resolved, setResolved] = useState<ResolvedTheme>(() => getInitialResolved(getInitialPreference()));
 
     useEffect(() => {
-        const initialPreference = readThemePreference();
-        const initialResolved = resolveTheme(initialPreference, getSystemTheme());
-        setPreferenceState(initialPreference);
-        setResolved(initialResolved);
-        applyTheme(initialResolved);
-    }, []);
+        applyTheme(resolved);
+    }, [resolved]);
 
     useEffect(() => {
-        if (!resolved || preference !== "system" || !window.matchMedia) return;
+        if (preference !== "system" || !window.matchMedia) return;
         const mq = window.matchMedia("(prefers-color-scheme: dark)");
         const listener = (evt: MediaQueryListEvent) => {
             const next = evt.matches ? "dark" : "light";
@@ -42,7 +46,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
         };
         mq.addEventListener("change", listener);
         return () => mq.removeEventListener("change", listener);
-    }, [preference, resolved]);
+    }, [preference]);
 
     const setPreference = useCallback((next: ThemePreference) => {
         writeThemePreference(next);
@@ -54,9 +58,9 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
 
     const value = useMemo<ThemeContextValue>(() => ({
         preference,
-        resolved: resolved ?? "light",
+        resolved,
         setPreference,
-        ready: resolved !== undefined,
+        ready: true,
     }), [preference, resolved, setPreference]);
 
     return (

--- a/src/common/ThemeProvider.tsx
+++ b/src/common/ThemeProvider.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import {
+    applyTheme,
+    getSystemTheme,
+    readThemePreference,
+    resolveTheme,
+    writeThemePreference,
+    type ResolvedTheme,
+    type ThemePreference,
+} from "./theme";
+
+type ThemeContextValue = {
+    preference: ThemePreference;
+    resolved: ResolvedTheme;
+    setPreference: (preference: ThemePreference) => void;
+    ready: boolean;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+    const [preference, setPreferenceState] = useState<ThemePreference>("system");
+    const [resolved, setResolved] = useState<ResolvedTheme | undefined>(undefined);
+
+    useEffect(() => {
+        const initialPreference = readThemePreference();
+        const initialResolved = resolveTheme(initialPreference, getSystemTheme());
+        setPreferenceState(initialPreference);
+        setResolved(initialResolved);
+        applyTheme(initialResolved);
+    }, []);
+
+    useEffect(() => {
+        if (!resolved || preference !== "system" || !window.matchMedia) return;
+        const mq = window.matchMedia("(prefers-color-scheme: dark)");
+        const listener = (evt: MediaQueryListEvent) => {
+            const next = evt.matches ? "dark" : "light";
+            applyTheme(next);
+            setResolved(next);
+        };
+        mq.addEventListener("change", listener);
+        return () => mq.removeEventListener("change", listener);
+    }, [preference, resolved]);
+
+    const setPreference = useCallback((next: ThemePreference) => {
+        writeThemePreference(next);
+        setPreferenceState(next);
+        const nextResolved = resolveTheme(next, getSystemTheme());
+        applyTheme(nextResolved);
+        setResolved(nextResolved);
+    }, []);
+
+    const value = useMemo<ThemeContextValue>(() => ({
+        preference,
+        resolved: resolved ?? "light",
+        setPreference,
+        ready: resolved !== undefined,
+    }), [preference, resolved, setPreference]);
+
+    return (
+        <ThemeContext.Provider value={value}>
+            {children}
+        </ThemeContext.Provider>
+    );
+}
+
+export function useTheme() {
+    const ctx = useContext(ThemeContext);
+    if (!ctx) {
+        throw new Error("useTheme must be used within ThemeProvider");
+    }
+    return ctx;
+}

--- a/src/common/apiurl.tsx
+++ b/src/common/apiurl.tsx
@@ -1,11 +1,72 @@
 export const APIUrlDefault = ""
 export const APIUrlKey = "api_url_v2"
+export const APIUrlListKey = "api_url_list_v2"
 export const AuthTokenKey = "auth_token"
+
+export function normalizeApiUrl(value?: string) {
+    const trimmed = (value ?? "").trim()
+    if (!trimmed) return ""
+    return trimmed.replace(/\/+$/, "")
+}
 
 export function getApiUrl() {
     const apiUrl = localStorage.getItem(APIUrlKey)
     if (!apiUrl) return APIUrlDefault
-    return JSON.parse(apiUrl)
+    try {
+        return normalizeApiUrl(JSON.parse(apiUrl))
+    } catch {
+        return normalizeApiUrl(apiUrl)
+    }
+}
+
+export function setApiUrl(url: string) {
+    localStorage.setItem(APIUrlKey, JSON.stringify(normalizeApiUrl(url)))
+}
+
+function readStoredApiUrlList(): string[] {
+    const raw = localStorage.getItem(APIUrlListKey)
+    if (!raw) return []
+    try {
+        const parsed = JSON.parse(raw)
+        if (!Array.isArray(parsed)) return []
+        return uniqueApiUrls(parsed.map((item) => String(item ?? "")))
+    } catch {
+        return []
+    }
+}
+
+export function uniqueApiUrls(urls: string[]) {
+    const seen = new Set<string>()
+    const out: string[] = []
+    for (const url of urls) {
+        const normalized = normalizeApiUrl(url)
+        if (seen.has(normalized)) continue
+        seen.add(normalized)
+        out.push(normalized)
+    }
+    return out
+}
+
+/** Saved controller hosts, always including the currently active URL. */
+export function getApiUrlList() {
+    const current = getApiUrl()
+    return uniqueApiUrls([current, ...readStoredApiUrlList()])
+}
+
+export function setApiUrlList(urls: string[]) {
+    const list = uniqueApiUrls(urls)
+    localStorage.setItem(APIUrlListKey, JSON.stringify(list))
+    return list
+}
+
+export function addApiUrl(url: string) {
+    const normalized = normalizeApiUrl(url)
+    return setApiUrlList([...getApiUrlList(), normalized])
+}
+
+export function removeApiUrl(url: string) {
+    const normalized = normalizeApiUrl(url)
+    return setApiUrlList(getApiUrlList().filter((item) => item !== normalized))
 }
 
 export const LatencyHTTPUrlDefault = "https://clients3.google.com/generate_204"

--- a/src/common/theme.ts
+++ b/src/common/theme.ts
@@ -1,0 +1,38 @@
+export type ThemePreference = "system" | "light" | "dark";
+export type ResolvedTheme = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "yuhaiin.theme";
+
+export function readThemePreference(): ThemePreference {
+    if (typeof window === "undefined") return "system";
+    try {
+        const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+        if (stored === "light" || stored === "dark" || stored === "system") {
+            return stored;
+        }
+    } catch {
+        // ignore storage errors
+    }
+    return "system";
+}
+
+export function writeThemePreference(preference: ThemePreference) {
+    try {
+        window.localStorage.setItem(THEME_STORAGE_KEY, preference);
+    } catch {
+        // ignore storage errors
+    }
+}
+
+export function getSystemTheme(): ResolvedTheme {
+    if (typeof window === "undefined" || !window.matchMedia) return "light";
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+export function resolveTheme(preference: ThemePreference, systemTheme: ResolvedTheme = getSystemTheme()): ResolvedTheme {
+    return preference === "system" ? systemTheme : preference;
+}
+
+export function applyTheme(theme: ResolvedTheme) {
+    document.documentElement.setAttribute("data-bs-theme", theme);
+}

--- a/src/component/v2/accordion.tsx
+++ b/src/component/v2/accordion.tsx
@@ -1,14 +1,13 @@
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { clsx } from 'clsx';
-import React from 'react';
 import { ChevronDown } from 'lucide-react';
+import React from 'react';
 
 const Accordion = React.forwardRef<React.ElementRef<typeof AccordionPrimitive.Root>, React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Root>>(({ className, ...props }, ref) => (
     <AccordionPrimitive.Root
         ref={ref}
         className={clsx(
-            "relative flex min-w-0 max-w-full flex-col w-full rounded-[20px] mb-8 transition-all duration-300 shadow-[0_20px_25px_-5px_rgba(0,0,0,0.1),0_10px_10px_-5px_rgba(0,0,0,0.04)]",
-            "hover:-translate-y-[5px] hover:border-[rgba(99,102,241,0.3)] hover:shadow-[0_0_30px_rgba(99,102,241,0.1)]",
+            "relative flex min-w-0 max-w-full flex-col w-full rounded-ui-xl mb-8 border border-transparent shadow-ui-card",
             className
         )}
         {...props}
@@ -20,10 +19,10 @@ const AccordionItem = React.forwardRef<React.ElementRef<typeof AccordionPrimitiv
     <AccordionPrimitive.Item
         ref={ref}
         className={clsx(
-            "min-w-0 max-w-full border border-sidebar-border bg-[var(--bs-card-bg)] overflow-hidden -mt-px",
-            "first:mt-0 first:rounded-t-[20px] last:rounded-b-[20px]",
-            "focus-within:relative focus-within:z-10 focus-within:border-sidebar-active",
-            "hover:relative hover:z-10 hover:border-sidebar-active",
+            "min-w-0 max-w-full border border-ui-border bg-ui-surface overflow-hidden -mt-px",
+            "first:mt-0 first:rounded-t-ui-xl last:rounded-b-ui-xl",
+            "focus-within:relative focus-within:z-10 focus-within:border-ui-primary/40",
+            "hover:relative hover:z-10 hover:border-ui-primary/40",
             className
         )}
         {...props}
@@ -36,9 +35,9 @@ const AccordionTrigger = React.forwardRef<React.ElementRef<typeof AccordionPrimi
         <AccordionPrimitive.Trigger
             ref={ref}
             className={clsx(
-                "group flex min-w-0 flex-1 items-center justify-between p-4 text-base font-medium leading-none text-sidebar-color bg-transparent border-0 cursor-pointer transition-all duration-200 w-full text-left",
+                "group flex min-w-0 flex-1 items-center justify-between p-4 text-base font-medium leading-none text-sidebar-color bg-transparent border-0 border-b border-transparent cursor-pointer transition-colors duration-200 w-full text-left",
                 "hover:!bg-sidebar-hover hover:!text-sidebar-active",
-                "data-[state=open]:bg-sidebar-hover data-[state=open]:text-sidebar-active data-[state=open]:border-b data-[state=open]:border-sidebar-border",
+                "data-[state=open]:bg-sidebar-hover data-[state=open]:text-sidebar-active data-[state=open]:border-ui-border",
                 className
             )}
             {...props}
@@ -58,7 +57,8 @@ const AccordionContent = React.forwardRef<React.ElementRef<typeof AccordionPrimi
     <AccordionPrimitive.Content
         ref={ref}
         className={clsx(
-            "min-w-0 max-w-full overflow-hidden text-sidebar-color bg-[var(--bs-body-bg)] will-change-[height]",
+            // Match surface, not page bg — avoids a light band while height animates.
+            "min-w-0 max-w-full overflow-hidden text-ui-fg bg-ui-surface will-change-[height]",
             "data-[state=open]:animate-accordion-down data-[state=closed]:animate-accordion-up",
             className
         )}

--- a/src/component/v2/card.tsx
+++ b/src/component/v2/card.tsx
@@ -29,7 +29,7 @@ export const Card: FC<{
             !noMargin && (density === "compact" ? "mb-4" : "mb-8"),
             className
         )}
-        style={{ viewTransitionName: "config-card-root", ...style }}
+        style={style}
     >
         {children}
     </div>
@@ -322,16 +322,17 @@ export function CardRowList<T>({
     const renderRowItem = (value: T, localIndex: number) => {
         const index = getItemIndex ? getItemIndex(value, localIndex) : start + localIndex;
         const key = getKey ? getKey(value) : index;
+        const isLast = localIndex === visibleItems.length - 1;
         const item = (
-            <div className="flex">
+            <div className={clsx("flex", layout === "list" && !isLast && "border-b border-ui-border/70")}>
                 <ListItem
                     density={density}
                     className={clsx(
-                        "w-full",
+                        "group w-full",
                         layout === "list" && [
-                            "min-h-[56px] rounded-ui-md bg-transparent px-3.5 py-2",
-                            "border-ui-border/60 shadow-none hover:bg-ui-surface-muted hover:border-ui-primary/25",
-                            "hover:translate-x-0.5 transition-[background-color,border-color,transform] duration-150"
+                            "min-h-[64px] rounded-none border-0 bg-transparent px-3.5 py-3 shadow-none",
+                            "hover:bg-ui-surface-muted/70 hover:translate-x-0",
+                            "transition-colors duration-150"
                         ]
                     )}
                     onClick={() => onClickItem?.(value, index)}
@@ -360,7 +361,7 @@ export function CardRowList<T>({
     };
 
     return (
-        <Card density={density} className={layout === "list" ? "shadow-none" : undefined}>
+        <Card density={density} className={layout === "list" ? "overflow-hidden shadow-ui-card" : undefined}>
             {(header || (onAddNew && layout === "list")) && (
                 <CardHeader className={layout === "list" && onAddNew ? "flex-wrap gap-3" : undefined}>
                     {header && <div className="min-w-0 flex-1">{header}</div>}
@@ -371,10 +372,10 @@ export function CardRowList<T>({
                     )}
                 </CardHeader>
             )}
-            <CardBody density={density} className={layout === "list" ? "px-4 py-4" : undefined}>
+            <CardBody density={density} className={layout === "list" ? "!p-0" : undefined}>
                 <div className={clsx(
                     layout === "list"
-                        ? "flex flex-col gap-1.5"
+                        ? "flex flex-col"
                         : "grid grid-cols-[repeat(auto-fill,minmax(min(300px,100%),1fr))] gap-4"
                 )}>
                     {shouldAnimate ? (

--- a/src/component/v2/card.tsx
+++ b/src/component/v2/card.tsx
@@ -1,13 +1,13 @@
 'use client';
 
 import { clsx } from "clsx";
-import { AnimatePresence, motion } from 'motion/react';
 import { History, Plus, Search, TriangleAlert } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
 import React, { FC, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Badge } from "./badge";
 import { Pagination } from './pagination';
-import { ui } from "./styles";
+import { iconToneStyles, ui, type IconTone } from "./styles";
 
 type Density = "compact" | "normal";
 
@@ -48,7 +48,7 @@ export const CardBody: FC<{ children: React.ReactNode, className?: string, style
 );
 
 export const CardTitle: FC<{ children: React.ReactNode, className?: string, style?: React.CSSProperties }> = ({ children, className, style }) => (
-    <div className={clsx("flex items-center mb-3 text-[1.1rem] font-semibold text-ui-heading", className)} style={style}>
+    <div className={clsx("flex items-center mb-3", ui.pageTitle, className)} style={style}>
         {children}
     </div>
 );
@@ -432,7 +432,7 @@ export const IconBadge: FC<{ icon: React.ElementType, text: string | number, col
 );
 
 export const MainContainer: FC<{ children: React.ReactNode, className?: string, style?: React.CSSProperties }> = ({ children, className, style }) => (
-    <div className={className} style={style}>
+    <div className={clsx("min-w-0 w-full", className)} style={style}>
         {children}
     </div>
 );
@@ -443,9 +443,28 @@ export const SettingsBox: FC<{ children: React.ReactNode }> = ({ children }) => 
     </div>
 );
 
+function resolveIconToneStyle(options: {
+    tone?: IconTone;
+    color?: string;
+    borderColor?: string;
+    background?: string;
+}) {
+    const tone = options.tone ?? (options.color ? undefined : "primary");
+    const toneStyle = tone ? iconToneStyles[tone] : undefined;
+    const color = options.color ?? toneStyle?.color ?? "var(--color-primary)";
+    const borderColor = options.borderColor
+        ?? toneStyle?.border
+        ?? (options.color ? `${options.color}33` : iconToneStyles.primary.border);
+    const background = options.background
+        ?? toneStyle?.background
+        ?? (options.color ? `${options.color}1A` : iconToneStyles.primary.background);
+    return { color, borderColor, background };
+}
+
 export const IconBox: FC<{
     icon: React.ElementType,
-    color: string,
+    color?: string,
+    tone?: IconTone,
     borderColor?: string,
     background?: string,
     className?: string,
@@ -453,38 +472,45 @@ export const IconBox: FC<{
     title?: string,
     description?: string,
     style?: React.CSSProperties
-}> = ({ icon: Icon, color, borderColor, background, className, textClassName, style, title, description }) => (
-    <div className="flex items-center min-w-0">
-        <div
-            className={clsx("flex shrink-0 items-center justify-center w-icon-lg h-icon-lg mr-5 text-xl rounded-ui-lg border", className)}
-            style={{ color: color, borderColor: borderColor || `${color}33`, background: background || `${color}1A`, ...style }}
-        >
-            <Icon />
-        </div>
-        {title &&
-            <div className={clsx("overflow-hidden", textClassName)} title={`${title}${description ? ` - ${description}` : ''}`}>
-                <h5 className="mb-0 font-bold truncate text-ui-heading">{title}</h5>
-                <small className="block text-ui-muted truncate">{description}</small>
+}> = ({ icon: Icon, color, tone, borderColor, background, className, textClassName, style, title, description }) => {
+    const resolved = resolveIconToneStyle({ tone, color, borderColor, background });
+    return (
+        <div className="flex items-center min-w-0">
+            <div
+                className={clsx("flex shrink-0 items-center justify-center w-icon-lg h-icon-lg mr-5 text-xl rounded-ui-lg border", className)}
+                style={{ color: resolved.color, borderColor: resolved.borderColor, background: resolved.background, ...style }}
+            >
+                <Icon />
             </div>
-        }
-    </div>
-);
+            {title &&
+                <div className={clsx("overflow-hidden", textClassName)} title={`${title}${description ? ` - ${description}` : ''}`}>
+                    <h5 className="mb-0 font-bold truncate text-ui-heading">{title}</h5>
+                    <small className="block text-ui-muted truncate">{description}</small>
+                </div>
+            }
+        </div>
+    );
+};
 
 export const IconBoxRounded: FC<{
     icon: React.ElementType,
-    color: string,
+    color?: string,
+    tone?: IconTone,
     borderColor?: string,
     background?: string,
     className?: string,
     style?: React.CSSProperties
-}> = ({ icon: Icon, color, borderColor, background, className, style }) => (
-    <div
-        className={clsx("flex shrink-0 items-center justify-center w-icon-lg h-icon-lg rounded-full border", className)}
-        style={{ color: color, borderColor: borderColor || `${color}33`, background: background || `${color}1A`, ...style }}
-    >
-        <Icon />
-    </div>
-);
+}> = ({ icon: Icon, color, tone, borderColor, background, className, style }) => {
+    const resolved = resolveIconToneStyle({ tone, color, borderColor, background });
+    return (
+        <div
+            className={clsx("flex shrink-0 items-center justify-center w-icon-lg h-icon-lg rounded-full border", className)}
+            style={{ color: resolved.color, borderColor: resolved.borderColor, background: resolved.background, ...style }}
+        >
+            <Icon />
+        </div>
+    );
+};
 
 export const FilterSearch: FC<{
     onEnter: (str: string) => void,

--- a/src/component/v2/combobox.tsx
+++ b/src/component/v2/combobox.tsx
@@ -1,7 +1,7 @@
 
 import * as Popover from '@radix-ui/react-popover';
-import React, { FC, useEffect, useState } from 'react';
 import { clsx } from 'clsx';
+import React, { FC, useEffect, useState } from 'react';
 import { Input, InputProps } from './input';
 
 export interface ComboboxItem {
@@ -123,7 +123,7 @@ export const Combobox: FC<ComboboxProps> = ({
                 <Popover.Portal>
                     <Popover.Content
                         className={clsx(
-                            "w-[var(--radix-popover-trigger-width)] max-h-[50vh] bg-[var(--bs-body-bg)] rounded-[20px] border border-[var(--bs-border-color)] shadow-lg z-[2000] p-1 will-change-[transform,opacity]",
+                            "w-[var(--radix-popover-trigger-width)] max-h-[50vh] bg-ui-surface rounded-ui-xl border border-ui-border shadow-ui-elevated z-[2000] p-1 will-change-[transform,opacity]",
                             "data-[state=open]:data-[side=top]:animate-slideDownAndFade data-[state=open]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[side=bottom]:animate-slideUpAndFade data-[state=open]:data-[side=left]:animate-slideRightAndFade"
                         )}
 
@@ -134,16 +134,8 @@ export const Combobox: FC<ComboboxProps> = ({
                         sideOffset={5}
                         collisionPadding={10}
                     >
-                        <div style={{
-                            borderRadius: '20px',
-                            overflow: 'hidden',
-                        }}>
-                            <div style={{
-                                width: '100%',
-                                height: '100%',
-                                overflowY: 'auto',
-                                maxHeight: '49vh',
-                            }}>
+                        <div className="rounded-ui-xl overflow-hidden">
+                            <div className="w-full h-full overflow-y-auto max-h-[49vh]">
                                 {filteredOptions.map((opt, i) => (
                                     <div
                                         key={`${opt.value}-${i}`}
@@ -154,9 +146,9 @@ export const Combobox: FC<ComboboxProps> = ({
                                             }
                                         }}
                                         className={clsx(
-                                            "group p-2 px-3 cursor-pointer rounded-[20px] text-sm transition-colors duration-150 text-[var(--bs-body-color)]",
-                                            "hover:bg-[var(--bs-tertiary-bg)] hover:text-[var(--bs-body-color)]",
-                                            "data-[highlighted=true]:bg-[var(--bs-tertiary-bg)] data-[highlighted=true]:text-[var(--bs-body-color)]"
+                                            "group p-2 px-3 cursor-pointer rounded-ui-xl text-sm transition-colors duration-150 text-ui-fg",
+                                            "hover:bg-ui-hover hover:text-ui-fg",
+                                            "data-[highlighted=true]:bg-ui-hover data-[highlighted=true]:text-ui-fg"
                                         )}
                                         data-highlighted={i === highlightedIndex}
                                         onClick={() => {
@@ -170,7 +162,7 @@ export const Combobox: FC<ComboboxProps> = ({
                                     >
                                         <span className="font-medium block">{opt.label}</span>
                                         {opt.details && opt.details.length > 0 && (
-                                            <div className="pl-0 mt-[2px] font-mono text-[0.75em] text-[var(--bs-secondary-color)] whitespace-nowrap overflow-hidden text-ellipsis group-hover:text-[var(--bs-secondary-color)] group-data-[highlighted=true]:text-[var(--bs-secondary-color)]">
+                                            <div className="pl-0 mt-[2px] font-mono text-[0.75em] text-ui-muted whitespace-nowrap overflow-hidden text-ellipsis">
                                                 {opt.details.map((d, di) => (
                                                     <span key={di} className="inline-block mr-[6px] last:mr-0 after:content-[','] last:after:content-['']">{d}</span>
                                                 ))}

--- a/src/component/v2/dropdown.tsx
+++ b/src/component/v2/dropdown.tsx
@@ -18,12 +18,11 @@ const DropdownContent = ({ className, sideOffset = 4, children, ...props }: Reac
             {...props}
         >
             <motion.div
-                initial={{ opacity: 0, scale: 0.95, y: -2 }}
+                initial={{ opacity: 0, scale: 0.96, y: -4 }}
                 animate={{ opacity: 1, scale: 1, y: 0 }}
-                transition={{ duration: 0.15, ease: "easeOut" }}
+                transition={{ duration: 0.14, ease: "easeOut" }}
                 className={clsx(
                     "bg-ui-surface border border-ui-border shadow-ui-elevated rounded-ui-xl min-w-[12rem] py-1.5 flex flex-col z-[2000] w-[var(--radix-dropdown-menu-trigger-width)] max-w-[var(--radix-dropdown-menu-trigger-width)] will-change-[transform,opacity]",
-                    "data-[side=bottom]:animate-slideUpAndFade data-[side=top]:animate-slideDownAndFade data-[state=closed]:animate-fadeOut",
                     className
                 )}
             >

--- a/src/component/v2/forms.tsx
+++ b/src/component/v2/forms.tsx
@@ -2,7 +2,6 @@
 
 import * as SliderPrimitive from '@radix-ui/react-slider';
 import { clsx } from 'clsx';
-import { motion } from 'motion/react';
 import { CircleAlert, Eye, EyeOff } from 'lucide-react';
 import React, { FC, useEffect, useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -161,18 +160,14 @@ export const SettingRangeVertical: FC<{
                 step={step}
             >
                 <SliderPrimitive.Track className="bg-ui-surface-muted relative grow rounded-full h-[3px]">
-                    <SliderPrimitive.Range className="absolute bg-ui-primary rounded-full h-full" asChild>
-                        <motion.span layout transition={{ type: "spring", stiffness: 400, damping: 30 }} />
-                    </SliderPrimitive.Range>
+                    <SliderPrimitive.Range className="absolute bg-ui-primary rounded-full h-full transition-[width] duration-150 ease-out" />
                 </SliderPrimitive.Track>
-                <SliderPrimitive.Thumb className={clsx("block w-[20px] h-[20px] bg-ui-bg shadow-ui-card rounded-full border border-ui-border hover:bg-ui-surface", ui.focusRing)} asChild>
-                    <motion.span
-                        layout
-                        whileHover={{ scale: 1.2 }}
-                        whileTap={{ scale: 0.9 }}
-                        transition={{ type: "spring", stiffness: 400, damping: 20 }}
-                    />
-                </SliderPrimitive.Thumb>
+                <SliderPrimitive.Thumb
+                    className={clsx(
+                        "block h-[20px] w-[20px] rounded-full border border-ui-border bg-ui-bg shadow-ui-card transition-transform duration-150 ease-out hover:scale-110 hover:bg-ui-surface active:scale-95",
+                        ui.focusRing
+                    )}
+                />
             </SliderPrimitive.Root>
 
             <div className="flex justify-between text-ui-muted opacity-50 text-[0.7rem] font-semibold">

--- a/src/component/v2/inputgroup.tsx
+++ b/src/component/v2/inputgroup.tsx
@@ -90,16 +90,15 @@ const InputGroupText = React.forwardRef<
     // Logic for radius based on position:
     const radiusClass =
         groupPosition === 'first' ? '!rounded-r-none !border-r-0' :
-        groupPosition === 'last' ? '!rounded-l-none' :
-        groupPosition === 'middle' ? '!rounded-none !border-r-0' :
-        ''; // single -> keep default radius
+            groupPosition === 'last' ? '!rounded-l-none' :
+                groupPosition === 'middle' ? '!rounded-none !border-r-0' :
+                    ''; // single -> keep default radius
 
     return (
         <div
             ref={ref}
             className={clsx(
-                "flex items-center py-1.5 px-3 text-base font-normal leading-normal text-[#212529] text-center whitespace-nowrap bg-[#e9ecef] border border-[#dee2e6] rounded-[12px]",
-                "dark:bg-transparent dark:border-[var(--bs-border-color)] dark:text-[var(--bs-body-color)]",
+                "flex items-center py-1.5 px-3 text-base font-normal leading-normal text-ui-fg text-center whitespace-nowrap bg-ui-surface-muted border border-ui-border rounded-ui-md",
                 radiusClass,
                 className
             )}

--- a/src/component/v2/listeditor.tsx
+++ b/src/component/v2/listeditor.tsx
@@ -153,9 +153,9 @@ export const InputBytesList: FC<{
 
             <div className="flex flex-col gap-3">
                 {items.map((v, i) => (
-                    <div key={i} className="relative p-3 rounded-lg bg-[var(--bs-secondary-bg)] group">
+                    <div key={i} className="relative p-3 rounded-ui-md bg-ui-surface-muted group">
                         <div className="flex items-center justify-between mb-2">
-                            <small className="font-bold text-[var(--bs-secondary-color)]">ENTRY #{i + 1}</small>
+                            <small className="font-bold text-ui-muted">ENTRY #{i + 1}</small>
                             {!disabled && (
                                 <Button variant="outline-danger" size="sm" onClick={() => remove(i)}>
                                     <Trash size={16} />
@@ -173,7 +173,7 @@ export const InputBytesList: FC<{
                     </div>
                 ))}
                 {items.length === 0 && (
-                    <div className="py-4 italic text-center border border-dashed rounded-lg opacity-50 text-[var(--bs-secondary-color)]">
+                    <div className="py-4 italic text-center border border-dashed rounded-ui-md opacity-50 text-ui-muted">
                         No {title} entries yet.
                     </div>
                 )}

--- a/src/component/v2/modal.tsx
+++ b/src/component/v2/modal.tsx
@@ -63,7 +63,7 @@ const contentVariants = {
     },
     exit: {
         opacity: 0,
-        scale: 0.2, // Shrink back
+        scale: 0.2,
         y: "-50%",
         x: "-50%",
         transition: { duration: 0.2 }
@@ -91,7 +91,7 @@ const ModalContent = ({ className, children, style, ...props }: React.ComponentP
                     <DialogPrimitive.Content asChild forceMount>
                         <motion.div
                             className={clsx(
-                                "fixed top-1/2 left-1/2 min-w-0 w-[90vw] max-w-[var(--bs-modal-width,500px)] max-h-[85vh] z-[1055] flex flex-col outline-none overflow-hidden bg-ui-surface text-ui-fg border border-ui-border rounded-ui-xl shadow-ui-elevated p-[5px] will-change-[transform,opacity]",
+                                "fixed top-1/2 left-1/2 min-w-0 w-[90vw] max-w-[500px] max-h-[85vh] z-[1055] flex flex-col outline-none overflow-hidden bg-ui-surface text-ui-fg border border-ui-border rounded-ui-xl shadow-ui-elevated p-[5px] will-change-[transform,opacity]",
                                 className
                             )}
                             variants={contentVariants}

--- a/src/component/v2/sidebar.tsx
+++ b/src/component/v2/sidebar.tsx
@@ -2,8 +2,8 @@
 
 import * as CollapsiblePrimitive from "@radix-ui/react-collapsible";
 import { clsx } from "clsx";
-import { AnimatePresence, motion } from 'motion/react';
 import { ChevronRight } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
 import React from "react";
 
 /* -------------------------------------------------------------------------- */
@@ -78,7 +78,7 @@ const SidebarItem = React.forwardRef<HTMLAnchorElement, SidebarItemProps>(({ cla
         <a
             ref={ref}
             className={clsx(
-                "flex items-center w-full px-[18px] py-[12px] text-[0.95rem] font-medium text-sidebar-color rounded-[14px] transition-all duration-200 border-none tracking-[0.3px] no-underline cursor-pointer bg-transparent outline-none focus:outline-none",
+                "flex items-center w-full px-[18px] py-[12px] text-[0.95rem] font-medium text-sidebar-color rounded-ui-md transition-all duration-200 border-none no-underline cursor-pointer bg-transparent outline-none focus:outline-none",
                 "hover:bg-sidebar-hover hover:text-sidebar-active [&>svg]:hover:scale-[1.15] [&>svg]:hover:-rotate-[5deg]",
                 active && "!bg-sidebar-active-bg !text-sidebar-active font-semibold shadow-sidebar-active",
                 className
@@ -130,7 +130,7 @@ const SidebarCollapsible = React.forwardRef<HTMLDivElement, SidebarCollapsiblePr
                 <button
                     type="button"
                     className={clsx(
-                        "group flex items-center w-full px-[18px] py-[12px] text-[0.95rem] font-medium text-sidebar-color rounded-[14px] transition-all duration-200 border-none tracking-[0.3px] cursor-pointer bg-transparent outline-none focus:outline-none",
+                        "group flex items-center w-full px-[18px] py-[12px] text-[0.95rem] font-medium text-sidebar-color rounded-ui-md transition-all duration-200 border-none cursor-pointer bg-transparent outline-none focus:outline-none",
                         "hover:bg-sidebar-hover hover:text-sidebar-active [&>span>svg]:hover:scale-[1.15] [&>span>svg]:hover:-rotate-[5deg]",
                         active && "!bg-sidebar-active-bg !text-sidebar-active font-semibold shadow-sidebar-active"
                     )}

--- a/src/component/v2/styles.ts
+++ b/src/component/v2/styles.ts
@@ -2,6 +2,46 @@ import { clsx, type ClassValue } from "clsx";
 
 export const cn = (...values: ClassValue[]) => clsx(values);
 
+export type IconTone = "primary" | "success" | "warning" | "info" | "danger" | "neutral" | "violet";
+
+export const iconToneStyles: Record<IconTone, { color: string; border: string; background: string }> = {
+    primary: {
+        color: "var(--color-primary)",
+        border: "color-mix(in srgb, var(--color-primary) 20%, transparent)",
+        background: "var(--color-primary-soft)",
+    },
+    success: {
+        color: "var(--color-success)",
+        border: "color-mix(in srgb, var(--color-success) 20%, transparent)",
+        background: "var(--color-success-soft)",
+    },
+    warning: {
+        color: "var(--color-warning)",
+        border: "color-mix(in srgb, var(--color-warning) 20%, transparent)",
+        background: "var(--color-warning-soft)",
+    },
+    info: {
+        color: "var(--color-info)",
+        border: "color-mix(in srgb, var(--color-info) 20%, transparent)",
+        background: "var(--color-info-soft)",
+    },
+    danger: {
+        color: "var(--color-danger)",
+        border: "color-mix(in srgb, var(--color-danger) 20%, transparent)",
+        background: "var(--color-danger-soft)",
+    },
+    neutral: {
+        color: "var(--color-muted)",
+        border: "var(--color-border)",
+        background: "var(--color-surface-muted)",
+    },
+    violet: {
+        color: "var(--color-violet)",
+        border: "color-mix(in srgb, var(--color-violet) 20%, transparent)",
+        background: "var(--color-violet-soft)",
+    },
+};
+
 export const ui = {
     focusRing: "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ui-focus",
     interactive: "transition-colors duration-150 ease-in-out",
@@ -14,4 +54,10 @@ export const ui = {
     fieldDisabled: "disabled:bg-ui-surface-muted disabled:text-ui-muted disabled:cursor-not-allowed disabled:shadow-none",
     listRow: "flex items-center min-h-list-row p-4 cursor-pointer rounded-ui-md border border-transparent bg-ui-list transition-colors duration-200 hover:bg-ui-list-hover hover:border-ui-list-border-hover",
     sectionLabel: "block mb-2 text-[13px] font-medium leading-[1.2] text-ui-muted whitespace-nowrap overflow-hidden text-ellipsis cursor-pointer",
+    mutedText: "text-ui-muted",
+    pageTitle: "font-semibold text-[1.125rem] leading-tight text-ui-heading",
+    pageDescription: "mt-0.5 text-xs text-ui-muted",
+    softPanel: "rounded-ui-lg bg-ui-surface-muted border border-ui-border",
+    chip: "rounded-full px-2.5 py-0.5 text-xs font-medium bg-ui-chip text-ui-chip-fg",
+    switchTrack: "w-[42px] h-[25px] shrink-0 bg-ui-surface-muted rounded-full relative shadow-inner-subtle flex items-center p-[2px] border border-ui-border cursor-pointer transition-colors duration-150 ease-in-out data-[state=checked]:bg-ui-primary data-[state=checked]:justify-end disabled:opacity-50 disabled:cursor-not-allowed",
 };

--- a/src/component/v2/styles.ts
+++ b/src/component/v2/styles.ts
@@ -59,5 +59,6 @@ export const ui = {
     pageDescription: "mt-0.5 text-xs text-ui-muted",
     softPanel: "rounded-ui-lg bg-ui-surface-muted border border-ui-border",
     chip: "rounded-full px-2.5 py-0.5 text-xs font-medium bg-ui-chip text-ui-chip-fg",
-    switchTrack: "w-[42px] h-[25px] shrink-0 bg-ui-surface-muted rounded-full relative shadow-inner-subtle flex items-center p-[2px] border border-ui-border cursor-pointer transition-colors duration-150 ease-in-out data-[state=checked]:bg-ui-primary data-[state=checked]:justify-end disabled:opacity-50 disabled:cursor-not-allowed",
+    switchTrack: "w-[42px] h-[25px] shrink-0 bg-ui-surface-muted rounded-full relative shadow-inner-subtle flex items-center p-[2px] border border-ui-border cursor-pointer transition-colors duration-150 ease-in-out data-[state=checked]:bg-ui-primary disabled:opacity-50 disabled:cursor-not-allowed",
+    switchThumb: "block h-[21px] w-[21px] translate-x-0 rounded-full bg-white shadow-[0_1px_2px_rgba(0,0,0,0.1)] transition-transform duration-200 ease-out will-change-transform data-[state=checked]:translate-x-[17px]",
 };

--- a/src/component/v2/switch.tsx
+++ b/src/component/v2/switch.tsx
@@ -2,7 +2,6 @@
 
 import * as SwitchPrimitive from '@radix-ui/react-switch';
 import { clsx } from 'clsx';
-import { motion, Transition } from 'motion/react';
 import * as React from 'react';
 import { ui } from './styles';
 
@@ -13,12 +12,6 @@ interface SwitchProps {
   description?: string;
   disabled?: boolean;
 }
-
-const transition: Transition = {
-  type: "spring",
-  stiffness: 700,
-  damping: 30
-};
 
 const switchTrackClass = clsx(ui.switchTrack, ui.focusRing);
 
@@ -39,13 +32,7 @@ const SwitchComponent: React.FC<SwitchProps> = ({ checked, onCheckedChange, labe
         onCheckedChange={onCheckedChange}
         disabled={disabled}
       >
-        <SwitchPrimitive.Thumb asChild>
-          <motion.span
-            className="block w-[21px] h-[21px] bg-white rounded-full shadow-[0_1px_2px_rgba(0,0,0,0.1)] will-change-[transform]"
-            layout
-            transition={transition}
-          />
-        </SwitchPrimitive.Thumb>
+        <SwitchPrimitive.Thumb className={ui.switchThumb} />
       </SwitchPrimitive.Root>
     </div>
   );
@@ -79,13 +66,7 @@ export const SwitchCard: React.FC<SwitchProps & { className?: string }> = ({ lab
         onCheckedChange={onCheckedChange}
         disabled={disabled}
       >
-        <SwitchPrimitive.Thumb asChild>
-          <motion.span
-            className="block w-[21px] h-[21px] bg-white rounded-full shadow-[0_1px_2px_rgba(0,0,0,0.1)] will-change-[transform]"
-            layout
-            transition={transition}
-          />
-        </SwitchPrimitive.Thumb>
+        <SwitchPrimitive.Thumb className={ui.switchThumb} />
       </SwitchPrimitive.Root>
     </div>
   );
@@ -107,13 +88,7 @@ const Switch = ({ className, label, id, ...props }: React.ComponentProps<typeof 
         className={switchTrackClass}
         {...switchProps}
       >
-        <SwitchPrimitive.Thumb asChild>
-          <motion.span
-            className="block w-[21px] h-[21px] bg-white rounded-full shadow-[0_1px_2px_rgba(0,0,0,0.1)] will-change-[transform]"
-            layout
-            transition={transition}
-          />
-        </SwitchPrimitive.Thumb>
+        <SwitchPrimitive.Thumb className={ui.switchThumb} />
       </SwitchPrimitive.Root>
 
       {label && (

--- a/src/component/v2/switch.tsx
+++ b/src/component/v2/switch.tsx
@@ -4,6 +4,7 @@ import * as SwitchPrimitive from '@radix-ui/react-switch';
 import { clsx } from 'clsx';
 import { motion, Transition } from 'motion/react';
 import * as React from 'react';
+import { ui } from './styles';
 
 interface SwitchProps {
   checked: boolean;
@@ -19,24 +20,21 @@ const transition: Transition = {
   damping: 30
 };
 
+const switchTrackClass = clsx(ui.switchTrack, ui.focusRing);
+
 const SwitchComponent: React.FC<SwitchProps> = ({ checked, onCheckedChange, label, description, disabled }) => {
   const isChecked = Boolean(checked);
 
   return (
-    <div className={clsx("flex items-center justify-between", disabled && "opacity-60 pointer-events-none grayscale-[0.5]")}>
+    <div className={clsx("flex items-center justify-between", disabled && "opacity-60 pointer-events-none")}>
       {label && (
         <div className="mr-4">
           <div className="font-medium leading-tight">{label}</div>
-          {description && <div className="text-gray-500 text-xs mt-0.5">{description}</div>}
+          {description && <div className="text-ui-muted text-xs mt-0.5">{description}</div>}
         </div>
       )}
       <SwitchPrimitive.Root
-        className={clsx(
-          "w-[42px] h-[25px] shrink-0 bg-[var(--bs-secondary-bg,#e9ecef)] rounded-full relative shadow-[inset_0_0.125rem_0.25rem_rgba(0,0,0,0.075)] flex items-center p-[2px] border border-[var(--bs-border-color)] cursor-pointer transition-colors duration-150 ease-in-out",
-          "data-[state=checked]:bg-[var(--bs-primary,#0d6efd)] data-[state=checked]:justify-end",
-          "disabled:opacity-50 disabled:cursor-not-allowed",
-          "focus-visible:outline-none focus-visible:shadow-[0_0_0_0.25rem_rgba(13,110,253,0.25)]"
-        )}
+        className={switchTrackClass}
         checked={isChecked}
         onCheckedChange={onCheckedChange}
         disabled={disabled}
@@ -61,10 +59,10 @@ export const SwitchCard: React.FC<SwitchProps & { className?: string }> = ({ lab
   return (
     <div
       className={clsx(
-        "flex items-center cursor-pointer px-3 py-3 rounded-[12px] bg-[var(--bs-tertiary-bg)] border border-sidebar-border transition-all duration-200 mb-2 hover:bg-sidebar-hover hover:border-sidebar-active hover:-translate-y-[2px]",
+        "flex items-center cursor-pointer px-3 py-3 rounded-ui-md bg-ui-surface-muted border border-ui-border transition-all duration-200 mb-2 hover:bg-ui-hover hover:border-ui-primary/40 hover:-translate-y-[2px]",
         "justify-between",
         className,
-        disabled && "opacity-60 pointer-events-none grayscale-[0.5]"
+        disabled && "opacity-60 pointer-events-none"
       )}
       onClick={() => !disabled && onCheckedChange(!isChecked)}
       role="button"
@@ -73,15 +71,10 @@ export const SwitchCard: React.FC<SwitchProps & { className?: string }> = ({ lab
     >
       <div className="mr-4">
         <div className="font-medium leading-tight">{label}</div>
-        {description && <div className="text-gray-500 text-xs mt-0.5">{description}</div>}
+        {description && <div className="text-ui-muted text-xs mt-0.5">{description}</div>}
       </div>
       <SwitchPrimitive.Root
-        className={clsx(
-          "w-[42px] h-[25px] shrink-0 bg-[var(--bs-secondary-bg,#e9ecef)] rounded-full relative shadow-[inset_0_0.125rem_0.25rem_rgba(0,0,0,0.075)] flex items-center p-[2px] border border-[var(--bs-border-color)] cursor-pointer transition-colors duration-150 ease-in-out",
-          "data-[state=checked]:bg-[var(--bs-primary,#0d6efd)] data-[state=checked]:justify-end",
-          "disabled:opacity-50 disabled:cursor-not-allowed",
-          "focus-visible:outline-none focus-visible:shadow-[0_0_0_0.25rem_rgba(13,110,253,0.25)]"
-        )}
+        className={switchTrackClass}
         checked={isChecked}
         onCheckedChange={onCheckedChange}
         disabled={disabled}
@@ -99,12 +92,7 @@ export const SwitchCard: React.FC<SwitchProps & { className?: string }> = ({ lab
 };
 
 
-interface SwitchProps extends React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root> {
-  label?: string;
-}
-
 const Switch = ({ className, label, id, ...props }: React.ComponentProps<typeof SwitchPrimitive.Root> & { label?: string }) => {
-  // Generate a unique ID to associate the Label (if id is not passed from outside)
   const generatedId = React.useId();
   const switchId = id || generatedId;
   const switchProps = {
@@ -116,12 +104,7 @@ const Switch = ({ className, label, id, ...props }: React.ComponentProps<typeof 
     <div className={clsx("flex items-center gap-2 cursor-pointer", className)}>
       <SwitchPrimitive.Root
         id={switchId}
-        className={clsx(
-          "w-[42px] h-[25px] shrink-0 bg-[var(--bs-secondary-bg,#e9ecef)] rounded-full relative shadow-[inset_0_0.125rem_0.25rem_rgba(0,0,0,0.075)] flex items-center p-[2px] border border-[var(--bs-border-color)] cursor-pointer transition-colors duration-150 ease-in-out",
-          "data-[state=checked]:bg-[var(--bs-primary,#0d6efd)] data-[state=checked]:justify-end",
-          "disabled:opacity-50 disabled:cursor-not-allowed",
-          "focus-visible:outline-none focus-visible:shadow-[0_0_0_0.25rem_rgba(13,110,253,0.25)]"
-        )}
+        className={switchTrackClass}
         {...switchProps}
       >
         <SwitchPrimitive.Thumb asChild>
@@ -134,7 +117,7 @@ const Switch = ({ className, label, id, ...props }: React.ComponentProps<typeof 
       </SwitchPrimitive.Root>
 
       {label && (
-        <label className="text-base text-[var(--bs-body-color,#212529)] leading-[1.5] cursor-pointer select-none" htmlFor={switchId}>
+        <label className="text-base text-ui-fg leading-[1.5] cursor-pointer select-none" htmlFor={switchId}>
           {label}
         </label>
       )}

--- a/src/component/v2/toast.tsx
+++ b/src/component/v2/toast.tsx
@@ -83,26 +83,26 @@ export const GlobalToastProvider: React.FC<{ children: React.ReactNode, duration
                   }
                 }}
                 className={clsx(
-                  "bg-[rgba(var(--bs-body-bg-rgb,255,255,255),0.7)] backdrop-blur-[8px] rounded-[8px] border border-[var(--bs-border-color-translucent,rgba(0,0,0,0.1))] shadow-[0_0.5rem_1rem_rgba(0,0,0,0.1)] flex flex-col overflow-hidden",
-                  toast.type === 'info' && "border-l-4 border-l-[var(--bs-info)]",
-                  toast.type === 'error' && "border-l-4 border-l-[var(--bs-danger)]"
+                  "bg-ui-surface/80 backdrop-blur-[8px] rounded-ui-sm border border-ui-border shadow-ui-card flex flex-col overflow-hidden",
+                  toast.type === 'info' && "border-l-4 border-l-ui-info",
+                  toast.type === 'error' && "border-l-4 border-l-ui-danger"
                 )}
                 style={{ listStyle: 'none' }} // Ensure checking CSS doesn't fail
               >
-                <div className="flex justify-between items-center py-[0.5rem] px-[0.75rem] bg-[rgba(var(--bs-tertiary-bg-rgb,248,249,250),0.5)] border-b border-[var(--bs-border-color-translucent)]">
-                  <ToastPrimitive.Title className="text-[0.85rem] font-bold text-[var(--bs-body-color)] m-0">
+                <div className="flex justify-between items-center py-[0.5rem] px-[0.75rem] bg-ui-surface-muted/60 border-b border-ui-border">
+                  <ToastPrimitive.Title className="text-[0.85rem] font-bold text-ui-fg m-0">
                     {toast.type === 'error' ? t('toast.systemError') : t('toast.notification')}
                   </ToastPrimitive.Title>
 
-                  <div className="d-flex align-items-center gap-2">
-                    <small className="text-muted" style={{ fontSize: '0.75rem' }}>{t('toast.justNow')}</small>
-                    <ToastPrimitive.Close className="bg-transparent border-0 text-[var(--bs-secondary-color)] cursor-pointer opacity-50 transition-opacity duration-200 px-[4px] text-[1.2rem] leading-none hover:opacity-100" aria-label={t('action.close')}>
+                  <div className="flex items-center gap-2">
+                    <small className="text-ui-muted text-xs">{t('toast.justNow')}</small>
+                    <ToastPrimitive.Close className="bg-transparent border-0 text-ui-muted cursor-pointer opacity-50 transition-opacity duration-200 px-[4px] text-[1.2rem] leading-none hover:opacity-100" aria-label={t('action.close')}>
                       <span aria-hidden>×</span>
                     </ToastPrimitive.Close>
                   </div>
                 </div>
 
-                <ToastPrimitive.Description className="py-[0.75rem] px-[1rem] text-[var(--bs-body-color)] text-[0.9rem] leading-[1.4]">
+                <ToastPrimitive.Description className="py-[0.75rem] px-[1rem] text-ui-fg text-[0.9rem] leading-[1.4]">
                   {toast.text}
                 </ToastPrimitive.Description>
               </motion.li>

--- a/src/component/v2/togglegroup.tsx
+++ b/src/component/v2/togglegroup.tsx
@@ -45,10 +45,10 @@ const ToggleItem = ({ className, children, value, ...props }: React.ComponentPro
         <ToggleGroupPrimitive.Item
             className={clsx(
                 "bg-transparent text-sidebar-color border border-sidebar-border py-[6px] px-[12px] text-[0.875rem] font-medium cursor-pointer transition-all duration-200 flex items-center justify-center -mr-px whitespace-nowrap",
-                "first:rounded-l-[12px] last:rounded-r-[12px] last:mr-0",
+                "first:rounded-l-ui-md last:rounded-r-ui-md last:mr-0",
                 "hover:!bg-sidebar-hover hover:z-10",
                 "data-[state=on]:bg-transparent data-[state=on]:text-sidebar-active data-[state=on]:border-sidebar-active data-[state=on]:z-20 data-[state=on]:shadow-none data-[state=on]:font-semibold",
-                "focus-visible:outline-2 focus-visible:outline-[var(--bs-secondary)] focus-visible:outline-offset-2 focus-visible:z-30",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ui-focus focus-visible:z-30",
                 className
             )}
             value={value}

--- a/src/component/v2/tooltip.tsx
+++ b/src/component/v2/tooltip.tsx
@@ -29,7 +29,7 @@ export const Tooltip: FC<{ children: ReactNode, content: ReactNode }> = ({ child
                             animate={{ opacity: 1, scale: 1, y: "-100%", x: "-50%" }}
                             exit={{ opacity: 0, scale: 0.2, y: "-100%", x: "-50%" }}
                             transition={{ type: "spring", stiffness: 300, damping: 25 }}
-                            className="fixed p-[6px_10px] text-xs leading-normal text-white bg-black/85 rounded whitespace-normal text-center shadow-[0_2px_10px_rgba(0,0,0,0.2)] z-[9999] max-w-[200px] pointer-events-none origin-[center_bottom]"
+                            className="fixed p-[6px_10px] text-xs leading-normal text-ui-bg bg-ui-heading rounded-ui-sm whitespace-normal text-center shadow-ui-elevated z-[9999] max-w-[200px] pointer-events-none origin-[center_bottom]"
                             style={{
                                 left: coords.left,
                                 top: coords.top,
@@ -38,7 +38,7 @@ export const Tooltip: FC<{ children: ReactNode, content: ReactNode }> = ({ child
                         >
                             {content}
                             {/* Arrow */}
-                            <div className="absolute bottom-[-4px] left-1/2 -translate-x-1/2 border-t-[4px] border-x-[4px] border-b-0 border-solid border-[rgba(0,0,0,0.85)_transparent_transparent_transparent]" />
+                            <div className="absolute bottom-[-4px] left-1/2 -translate-x-1/2 border-t-[4px] border-x-[4px] border-b-0 border-solid border-ui-heading border-x-transparent border-b-transparent" />
                         </motion.div>
                     )}
                 </AnimatePresence>,

--- a/src/contract/route.ts
+++ b/src/contract/route.ts
@@ -103,15 +103,20 @@ export function normalizeRouteList(value: Partial<RouteListDetail>): RouteListDe
   };
 }
 
+function toUint(value: unknown, fallback = 0): number {
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) && n >= 0 ? Math.trunc(n) : fallback;
+}
+
 export function normalizeRuleItem(value: Partial<RuleItem> | undefined): RuleItem {
   return {
     name: value?.name ?? "",
     disabled: value?.disabled ?? false,
-    index: value?.index ?? 0,
+    index: toUint(value?.index),
     mode: value?.mode ?? "",
     tag: value?.tag ?? "",
     resolver: value?.resolver ?? "",
-    ruleCount: value?.ruleCount ?? 0,
+    ruleCount: toUint(value?.ruleCount),
   };
 }
 

--- a/src/contract/route.ts
+++ b/src/contract/route.ts
@@ -73,6 +73,7 @@ export function normalizeRouteListConfig(value: Partial<RouteListConfig> | undef
     refreshInterval: value?.refreshInterval ?? "0",
     lastRefreshTime: value?.lastRefreshTime ?? "0",
     error: value?.error ?? "",
+    hostIndexDisk: value?.hostIndexDisk ?? false,
     maxMindDbGeoIp: {
       downloadUrl: value?.maxMindDbGeoIp?.downloadUrl ?? "",
       error: value?.maxMindDbGeoIp?.error ?? "",

--- a/src/docs/bypass/block/page.tsx
+++ b/src/docs/bypass/block/page.tsx
@@ -172,6 +172,7 @@ function BypassBlockHistory() {
 
             <CardList
                 items={paginatedItems}
+                animated={false}
                 getKey={(v) => `${v.host}-${v.time}`}
                 onClickItem={(item) => setInfo({ show: true, data: item })}
                 renderListItem={(item) => <ListItem data={item} />}

--- a/src/docs/bypass/block/page.tsx
+++ b/src/docs/bypass/block/page.tsx
@@ -40,7 +40,7 @@ const ListItem: FC<{ data: BlockHistory }> = React.memo(({ data }) => {
 
                 <div className="flex flex-col overflow-hidden" style={{ minWidth: 0 }}>
                     <span className="font-bold truncate text-base opacity-75">{data.host}</span>
-                    <small className="text-gray-500 dark:text-gray-400 truncate opacity-75 font-mono">
+                    <small className="text-ui-muted truncate opacity-75 font-mono">
                         {data.process || "System Filter"}
                     </small>
                 </div>
@@ -57,7 +57,7 @@ const ListItem: FC<{ data: BlockHistory }> = React.memo(({ data }) => {
                 <Badge variant="secondary" pill className="flex items-center gap-1">
                     <Clock size={12} /> {historyDate(data.time).toLocaleTimeString()}
                 </Badge>
-                <ChevronRight className="text-gray-500 dark:text-gray-400 opacity-25 ml-2 hidden md:block" size={16} />
+                <ChevronRight className="text-ui-muted opacity-25 ml-2 hidden md:block" size={16} />
             </div>
         </div>
     );
@@ -129,7 +129,7 @@ function BypassBlockHistory() {
             <div className="flex flex-wrap justify-between items-end mb-4 gap-3">
                 <div>
                     <h4 className="font-bold mb-1">Blocked Traffic</h4>
-                    <div className="text-gray-500 dark:text-gray-400 flex items-center text-sm">
+                    <div className="text-ui-muted flex items-center text-sm">
                         <ShieldOff className="mr-2 text-red-500 opacity-75" />
                         <span>Displaying {values.length} connections denied by rules</span>
                     </div>

--- a/src/docs/bypass/list/page.tsx
+++ b/src/docs/bypass/list/page.tsx
@@ -4,7 +4,7 @@ import { createRouteList, deleteRouteList, getRouteActivationStatus, getRouteLis
 import { Badge } from "@/component/v2/badge";
 import { Button } from "@/component/v2/button";
 import { Card, CardBody, CardFooter, CardHeader, FilterSearch, IconBox, MainContainer, SettingLabel, SettingsBox } from "@/component/v2/card";
-import { SettingInputVertical, SettingRangeVertical, SettingSelectVertical } from "@/component/v2/forms";
+import { SettingInputVertical, SettingRangeVertical, SettingSelectVertical, SwitchCard } from "@/component/v2/forms";
 import { InputList } from "@/component/v2/listeditor";
 import Loading from "@/component/v2/loading";
 import { Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, ModalTitle } from "@/component/v2/modal";
@@ -351,6 +351,12 @@ function ListConfigCard() {
                             label="Maxmind GeoIP Database URL"
                             value={data.maxMindDbGeoIp.downloadUrl}
                             onChange={(downloadUrl) => patch({ maxMindDbGeoIp: { ...data.maxMindDbGeoIp, downloadUrl } })}
+                        />
+                        <SwitchCard
+                            label="Use Disk Host Index"
+                            description="Use the disk-backed host index to reduce memory usage."
+                            checked={data.hostIndexDisk}
+                            onCheckedChange={(hostIndexDisk) => patch({ hostIndexDisk })}
                         />
                         {(data.error || data.maxMindDbGeoIp.error) && (
                             <div className="md:col-span-2 rounded-ui-lg border border-ui-danger/40 bg-ui-danger/10 p-3 text-sm text-ui-danger">

--- a/src/docs/bypass/list/page.tsx
+++ b/src/docs/bypass/list/page.tsx
@@ -3,25 +3,194 @@
 import { createRouteList, deleteRouteList, getRouteActivationStatus, getRouteList, getRouteListConfig, listRouteLists, refreshRouteLists, saveRouteList, saveRouteListConfig } from "@/api/route";
 import { Badge } from "@/component/v2/badge";
 import { Button } from "@/component/v2/button";
-import { Card, CardBody, CardFooter, CardHeader, CardRowList, FilterSearch, IconBox, MainContainer, SettingLabel, SettingsBox } from "@/component/v2/card";
+import { Card, CardBody, CardFooter, CardHeader, FilterSearch, IconBox, MainContainer, SettingLabel, SettingsBox } from "@/component/v2/card";
 import { SettingInputVertical, SettingRangeVertical, SettingSelectVertical } from "@/component/v2/forms";
 import { InputList } from "@/component/v2/listeditor";
 import Loading from "@/component/v2/loading";
-import { RouteActivationProgress } from "@/component/v2/route-activation-progress";
 import { Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, ModalTitle } from "@/component/v2/modal";
+import { Pagination } from "@/component/v2/pagination";
+import { RouteActivationProgress } from "@/component/v2/route-activation-progress";
 import { Spinner } from "@/component/v2/spinner";
 import { GlobalToastContext } from "@/component/v2/toast";
 import { ToggleGroup, ToggleItem } from "@/component/v2/togglegroup";
-import type { RouteListDetail } from "@/contract/route";
+import type { ListItem, RouteListDetail } from "@/contract/route";
 import { createDefaultRouteList, normalizeRouteList } from "@/contract/route";
-import { Check, ChevronRight, Clock, CloudDownload, FileText, List, Network, Plus, RefreshCw, Save, Trash, TriangleAlert } from "lucide-react";
-import type { CSSProperties } from "react";
+import clsx from "clsx";
+import {
+    Check,
+    Clock,
+    Cloud,
+    CloudDownload,
+    FileText,
+    Globe2,
+    HardDrive,
+    Hash,
+    List,
+    Network,
+    Plus,
+    RefreshCw,
+    Regex,
+    Save,
+    TextCursorInput,
+    Trash,
+    TriangleAlert,
+    Type,
+} from "lucide-react";
+import type { CSSProperties, ElementType, FC } from "react";
 import { useContext, useEffect, useState } from "react";
 import useSWR from "swr";
 
 const routeListTypes = ["host", "process", "cidr", "domain", "regexp", "keyword", "suffix"];
 const sourceTypes = ["local", "remote"];
-const PAGE_SIZE = 8;
+const PAGE_SIZE = 12;
+
+type BadgeVariant = "primary" | "secondary" | "success" | "danger" | "warning" | "info" | "muted";
+
+function shortPreview(value?: string) {
+    const preview = (value || "").trim();
+    if (!preview) return "Empty list";
+    try {
+        if (/^https?:\/\//i.test(preview)) {
+            const url = new URL(preview);
+            const leaf = url.pathname.split("/").filter(Boolean).pop();
+            return leaf || url.host;
+        }
+    } catch {
+        // keep original preview
+    }
+    return preview;
+}
+
+function listTypeVisual(type?: string): {
+    icon: ElementType;
+    tone: string;
+    soft: string;
+    badge: BadgeVariant;
+} {
+    switch ((type || "").toLowerCase()) {
+        case "host":
+        case "domain":
+            return {
+                icon: Globe2,
+                tone: "text-ui-primary",
+                soft: "bg-ui-primary-soft border-ui-primary/15",
+                badge: "primary",
+            };
+        case "suffix":
+            return {
+                icon: Type,
+                tone: "text-ui-info",
+                soft: "bg-ui-info-soft border-ui-info/15",
+                badge: "info",
+            };
+        case "keyword":
+            return {
+                icon: Hash,
+                tone: "text-[var(--color-violet)]",
+                soft: "bg-[var(--color-violet-soft)] border-[color-mix(in_srgb,var(--color-violet)_18%,transparent)]",
+                badge: "secondary",
+            };
+        case "regexp":
+            return {
+                icon: Regex,
+                tone: "text-ui-danger",
+                soft: "bg-ui-danger-soft border-ui-danger/15",
+                badge: "danger",
+            };
+        case "cidr":
+            return {
+                icon: Network,
+                tone: "text-ui-success",
+                soft: "bg-ui-success-soft border-ui-success/15",
+                badge: "success",
+            };
+        case "process":
+            return {
+                icon: TextCursorInput,
+                tone: "text-ui-warning",
+                soft: "bg-ui-warning-soft border-ui-warning/15",
+                badge: "warning",
+            };
+        default:
+            return {
+                icon: FileText,
+                tone: "text-ui-muted",
+                soft: "bg-ui-surface-muted border-ui-border",
+                badge: "muted",
+            };
+    }
+}
+
+const DefinedListTile: FC<{ item: ListItem; onClick: () => void }> = ({ item, onClick }) => {
+    const visual = listTypeVisual(item.type);
+    const Icon = visual.icon;
+    const hasError = item.errorCount > 0;
+    const source = (item.source || "local").toLowerCase();
+    const remote = source === "remote";
+    const preview = shortPreview(item.preview);
+
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className={clsx(
+                "group flex h-full min-h-[140px] w-full flex-col rounded-ui-lg border bg-ui-surface p-4 text-left",
+                "shadow-sm transition-[border-color,box-shadow,transform,background-color] duration-150",
+                "hover:-translate-y-0.5 hover:border-ui-primary/35 hover:bg-ui-surface-muted/40 hover:shadow-md",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ui-primary/35",
+                hasError ? "border-ui-danger/30" : "border-ui-border"
+            )}
+        >
+            <div className="flex items-start justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-3">
+                    <div className={clsx(
+                        "flex h-10 w-10 shrink-0 items-center justify-center rounded-ui-lg border",
+                        hasError ? "border-ui-danger/20 bg-ui-danger-soft text-ui-danger" : clsx(visual.soft, visual.tone)
+                    )}>
+                        {hasError ? <TriangleAlert size={18} strokeWidth={1.9} /> : <Icon size={18} strokeWidth={1.9} />}
+                    </div>
+                    <div className="min-w-0">
+                        <div className="truncate text-[0.95rem] font-semibold text-ui-heading" title={item.name}>
+                            {item.name}
+                        </div>
+                        <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                            <Badge variant={hasError ? "danger" : visual.badge} pill className="px-2 py-0.5 text-[0.65rem] uppercase tracking-wide">
+                                {item.type || "list"}
+                            </Badge>
+                            <Badge variant={remote ? "info" : "muted"} pill className="px-2 py-0.5 text-[0.65rem]">
+                                {remote ? "Remote" : "Local"}
+                            </Badge>
+                            {hasError && (
+                                <Badge variant="danger" pill className="px-2 py-0.5 text-[0.65rem]">
+                                    {item.errorCount} error{item.errorCount === 1 ? "" : "s"}
+                                </Badge>
+                            )}
+                        </div>
+                    </div>
+                </div>
+                <div className="shrink-0 rounded-full border border-ui-border/70 bg-ui-surface-muted/70 px-2 py-1 text-[11px] font-semibold tabular-nums text-ui-muted">
+                    {item.itemCount}
+                </div>
+            </div>
+
+            <div className="mt-4 min-w-0 flex-1">
+                <div className="text-[11px] font-medium uppercase tracking-wide text-ui-muted/80">Preview</div>
+                <div className="mt-1 break-all font-mono text-[12.5px] font-medium leading-relaxed text-ui-fg" title={item.preview || undefined}>
+                    {preview}
+                </div>
+            </div>
+
+            <div className="mt-3 flex items-center gap-1.5 border-t border-ui-border/70 pt-3 text-[11px] text-ui-muted">
+                {remote ? <Cloud size={13} className="shrink-0 opacity-70" /> : <HardDrive size={13} className="shrink-0 opacity-70" />}
+                <span className="truncate">
+                    {remote ? "Fetched remotely" : "Defined locally"}
+                    <span className="mx-1.5 opacity-40">·</span>
+                    {item.itemCount} {item.itemCount === 1 ? "entry" : "entries"}
+                </span>
+            </div>
+        </button>
+    );
+};
 
 function Lists() {
     const ctx = useContext(GlobalToastContext);
@@ -42,7 +211,7 @@ function Lists() {
     const { data, error, isLoading, mutate } = useSWR(
         ["/api/v2/route/lists", page, query],
         () => listRouteLists({ page, pageSize: PAGE_SIZE, query }),
-        { revalidateOnFocus: false },
+        { revalidateOnFocus: false, keepPreviousData: true },
     );
 
     const refresh = async () => {
@@ -75,59 +244,58 @@ function Lists() {
         <MainContainer>
             <ListConfigCard />
             <RouteActivationProgress status={activation} onApplied={mutateActivation} />
-            <CardRowList
-                layout="list"
-                paginated
-                pageSize={PAGE_SIZE}
-                currentPage={data.page.page || page}
-                totalItems={data.page.total}
-                onPageChange={setPage}
-                items={data.items}
-                getKey={(v) => v.name}
-                renderListItem={(item) => (
-                    <div className="grid w-full min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-x-3">
-                        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-ui-md bg-ui-primary-soft text-ui-primary">
-                            <FileText size={19} />
-                        </div>
-                        <div className="min-w-0">
-                            <div className="flex min-w-0 flex-wrap items-center gap-2">
-                                <span className="truncate font-semibold text-ui-heading">{item.name}</span>
-                                <Badge variant="secondary" className="shrink-0">{item.type || "-"}</Badge>
-                                {item.errorCount > 0 && <Badge variant="danger" className="shrink-0">{item.errorCount} errors</Badge>}
-                            </div>
-                            <div className="mt-2 grid min-w-0 gap-2 text-xs text-ui-muted sm:grid-cols-[auto_auto_minmax(0,1fr)]">
-                                <span className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-ui-sm bg-ui-surface-muted px-2 py-1">
-                                    <span>Source</span>
-                                    <span className="font-medium text-ui-fg">{item.source || "-"}</span>
-                                </span>
-                                <span className="inline-flex items-center gap-1.5 whitespace-nowrap rounded-ui-sm bg-ui-surface-muted px-2 py-1">
-                                    <span>Entries</span>
-                                    <span className="font-medium text-ui-fg">{item.itemCount}</span>
-                                </span>
-                                <span className="flex min-w-0 items-center gap-1.5 rounded-ui-sm bg-ui-surface-muted px-2 py-1">
-                                    <span className="shrink-0">Preview</span>
-                                    <span className="min-w-0 truncate font-mono text-ui-fg">{item.preview || "-"}</span>
-                                </span>
-                            </div>
-                        </div>
-                        <ChevronRight className="shrink-0 text-ui-muted/55" size={20} />
-                    </div>
-                )}
-                onClickItem={(item) => setEditing(item.name)}
-                header={
+            <Card density="compact" className="overflow-hidden">
+                <CardHeader>
                     <div className="flex w-full flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
-                        <IconBox icon={List} tone="primary" title="Defined Lists" description={`${data.page.total} lists available`} />
+                        <IconBox
+                            icon={List}
+                            tone="primary"
+                            title="Defined Lists"
+                            description="Match sources for route rules"
+                        />
                         <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:flex-nowrap">
-                            <FilterSearch className="min-w-0 flex-1 sm:w-[180px] sm:flex-none" onEnter={(v) => { setPage(1); setQuery(v); }} size="sm" />
-                            <Button size="sm" onClick={refresh} disabled={isRefreshing}>
+                            <FilterSearch className="min-w-0 flex-1 sm:w-[200px] sm:flex-none" onEnter={(v) => { setPage(1); setQuery(v); }} size="sm" />
+                            <Button size="sm" variant="outline-secondary" onClick={refresh} disabled={isRefreshing}>
                                 {isRefreshing ? <Spinner size="sm" className="mr-2" /> : <RefreshCw size={16} className="mr-2" />}
-                                Sync All Resources
+                                Sync
                             </Button>
-                            <Button size="sm" onClick={() => { setCreatingName(""); setCreating(true); }}><Plus size={16} className="mr-1" /> Add</Button>
+                            <Button size="sm" onClick={() => { setCreatingName(""); setCreating(true); }}>
+                                <Plus size={16} className="mr-1" /> Add
+                            </Button>
                         </div>
                     </div>
-                }
-            />
+                </CardHeader>
+                <CardBody density="compact">
+                    {data.items.length === 0 ? (
+                        <div className="rounded-ui-lg border border-dashed border-ui-border px-4 py-10 text-center text-sm text-ui-muted">
+                            No lists yet. Create a local list or sync remote sources.
+                        </div>
+                    ) : (
+                        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                            {data.items.map((item) => (
+                                <DefinedListTile
+                                    key={item.name}
+                                    item={item}
+                                    onClick={() => setEditing(item.name)}
+                                />
+                            ))}
+                        </div>
+                    )}
+                </CardBody>
+                {data.page.total > PAGE_SIZE && (
+                    <CardFooter compact className="flex items-center justify-between gap-3">
+                        <div className="text-xs font-medium text-ui-muted">
+                            {data.page.total} items · page {data.page.page || page}/{Math.max(1, Math.ceil(data.page.total / (data.page.pageSize || PAGE_SIZE)))}
+                        </div>
+                        <Pagination
+                            currentPage={data.page.page || page}
+                            totalItems={data.page.total}
+                            pageSize={data.page.pageSize || PAGE_SIZE}
+                            onPageChange={setPage}
+                        />
+                    </CardFooter>
+                )}
+            </Card>
             <ListEditorModal name={editing} onSaved={saved} onClose={() => setEditing(null)} />
             <CreateListModal open={creating} initialName={creatingName} onSaved={saved} onClose={() => setCreating(false)} />
         </MainContainer>

--- a/src/docs/bypass/list/page.tsx
+++ b/src/docs/bypass/list/page.tsx
@@ -116,7 +116,7 @@ function Lists() {
                 onClickItem={(item) => setEditing(item.name)}
                 header={
                     <div className="flex w-full flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
-                        <IconBox icon={List} color="#2563eb" title="Defined Lists" description={`${data.page.total} lists available`} />
+                        <IconBox icon={List} tone="primary" title="Defined Lists" description={`${data.page.total} lists available`} />
                         <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:flex-nowrap">
                             <FilterSearch className="min-w-0 flex-1 sm:w-[180px] sm:flex-none" onEnter={(v) => { setPage(1); setQuery(v); }} size="sm" />
                             <Button size="sm" onClick={refresh} disabled={isRefreshing}>
@@ -162,7 +162,7 @@ function ListConfigCard() {
     return (
         <Card className="mb-4">
             <CardHeader>
-                <IconBox icon={Clock} color="#10b981" title="List Synchronization" description={`Last Synced: ${lastSync}`} />
+                <IconBox icon={Clock} tone="success" title="List Synchronization" description={`Last Synced: ${lastSync}`} />
                 {isLoading && <Spinner size="sm" />}
             </CardHeader>
             <CardBody>
@@ -340,7 +340,7 @@ function RouteListForm({ value, onChange, lockName }: { value: RouteListDetail; 
                 <div className="flex flex-wrap items-end justify-between gap-3 px-1">
                     <div>
                         <h6 className="mb-1 font-bold">{sourceType === "remote" ? "Remote Resource URLs" : "Local Rules"}</h6>
-                        <small className="text-gray-500 dark:text-gray-400">
+                        <small className="text-ui-muted">
                             {sourceType === "remote" ? "Files will be downloaded and updated automatically." : "Define rules manually for this list."}
                         </small>
                     </div>

--- a/src/docs/bypass/page.tsx
+++ b/src/docs/bypass/page.tsx
@@ -191,18 +191,19 @@ function BypassComponent() {
         () => listRules({ page, pageSize: PAGE_SIZE, query }),
         { revalidateOnFocus: false },
     );
+    const needEditorOptions = creating || editing !== null;
     const { data: allRules, mutate: mutateAllRules } = useSWR(
-        "/api/v2/route/rules/all",
+        priorityItem ? "/api/v2/route/rules/all" : null,
         () => listRules({ page: 1, pageSize: 10000 }),
         { revalidateOnFocus: false },
     );
     const { data: listsData } = useSWR(
-        "/api/v2/route/lists/options",
+        needEditorOptions ? "/api/v2/route/lists/options" : null,
         () => listRouteLists({ page: 1, pageSize: 10000 }),
         { revalidateOnFocus: false },
     );
     const { data: inboundsData } = useSWR(
-        "/api/v2/inbounds/options",
+        needEditorOptions ? "/api/v2/inbounds/options" : null,
         () => listInbounds({ page: 1, pageSize: 10000 }),
         { revalidateOnFocus: false },
     );

--- a/src/docs/bypass/page.tsx
+++ b/src/docs/bypass/page.tsx
@@ -17,6 +17,7 @@ import { Spinner } from "@/component/v2/spinner";
 import { GlobalToastContext } from "@/component/v2/toast";
 import type { RouteRule, RuleExpr, RuleItem } from "@/contract/route";
 import { createDefaultRule, normalizeRule } from "@/contract/route";
+import clsx from "clsx";
 import { ArrowUpDown, Plus, Power, Route, Save, ShieldCheck, Trash, X } from "lucide-react";
 import type { CSSProperties } from "react";
 import { useContext, useEffect, useMemo, useState } from "react";
@@ -28,6 +29,128 @@ const udpProxyStrategies = ["udp_proxy_fqdn_strategy_default", "udp_proxy_fqdn_s
 const leafRuleExprTypes = ["host", "process", "inbound", "network", "port", "geoip"];
 type PriorityOperate = "exchange" | "insert_before" | "insert_after";
 const PAGE_SIZE = 8;
+
+type BadgeVariant = "primary" | "secondary" | "success" | "danger" | "warning" | "info" | "muted";
+
+function modeBadgeVariant(mode: string): BadgeVariant {
+    switch (mode.toLowerCase()) {
+        case "proxy":
+            return "primary";
+        case "direct":
+            return "success";
+        case "block":
+            return "danger";
+        case "bypass":
+            return "warning";
+        default:
+            return "muted";
+    }
+}
+
+function modeIconTone(mode: string): "primary" | "success" | "danger" | "warning" | "violet" {
+    switch (mode.toLowerCase()) {
+        case "proxy":
+            return "primary";
+        case "direct":
+            return "success";
+        case "block":
+            return "danger";
+        case "bypass":
+            return "warning";
+        default:
+            return "violet";
+    }
+}
+
+const MetaChip = ({ label, value, mono = false }: { label: string; value: string | number; mono?: boolean }) => (
+    <span className="inline-flex min-w-0 max-w-full items-center gap-1.5 rounded-full border border-ui-border/70 bg-ui-surface-muted/70 px-2.5 py-1 text-[11px] text-ui-muted">
+        <span className="shrink-0 uppercase tracking-wide opacity-80">{label}</span>
+        <span className={clsx("min-w-0 truncate font-semibold text-ui-fg", mono && "font-mono")}>{value}</span>
+    </span>
+);
+
+const RuleListItem = ({
+    item,
+    onPriority,
+    onToggle,
+}: {
+    item: RuleItem;
+    onPriority: () => void;
+    onToggle: () => void;
+}) => (
+    <div className={clsx(
+        "grid w-full min-w-0 grid-cols-1 items-center gap-3 sm:grid-cols-[minmax(0,1fr)_auto]",
+        item.disabled && "opacity-60"
+    )}>
+        <div className="flex min-w-0 items-start gap-3">
+            <div className="flex shrink-0 flex-col items-center gap-1 pt-0.5">
+                <span className="font-mono text-[11px] font-semibold tabular-nums text-ui-muted">
+                    #{item.index}
+                </span>
+                <div className={clsx(
+                    "flex h-9 w-9 items-center justify-center rounded-ui-lg border",
+                    item.disabled
+                        ? "border-ui-border bg-ui-surface-muted text-ui-muted"
+                        : modeIconTone(item.mode) === "primary"
+                            ? "border-ui-primary/20 bg-ui-primary-soft text-ui-primary"
+                            : modeIconTone(item.mode) === "success"
+                                ? "border-ui-success/20 bg-ui-success-soft text-ui-success"
+                                : modeIconTone(item.mode) === "danger"
+                                    ? "border-ui-danger/20 bg-ui-danger-soft text-ui-danger"
+                                    : modeIconTone(item.mode) === "warning"
+                                        ? "border-ui-warning/20 bg-ui-warning-soft text-ui-warning"
+                                        : "border-ui-border bg-ui-surface-muted text-ui-muted"
+                )}>
+                    <Route size={17} />
+                </div>
+            </div>
+
+            <div className="min-w-0 flex-1">
+                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                    <span className="truncate text-[0.95rem] font-semibold text-ui-heading" title={item.name}>
+                        {item.name}
+                    </span>
+                    <Badge variant={modeBadgeVariant(item.mode)} pill className="px-2 py-0.5 text-[0.65rem] uppercase tracking-wide">
+                        {item.mode || "unknown"}
+                    </Badge>
+                    {item.disabled && (
+                        <Badge variant="secondary" pill className="px-2 py-0.5 text-[0.65rem]">
+                            Off
+                        </Badge>
+                    )}
+                </div>
+                <div className="mt-2 flex min-w-0 flex-wrap gap-1.5">
+                    <MetaChip label="Rules" value={item.ruleCount} />
+                    <MetaChip label="Tag" value={item.tag || "—"} />
+                    <MetaChip label="Resolver" value={item.resolver || "—"} mono />
+                </div>
+            </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1.5 self-end sm:self-auto">
+            <Button
+                size="icon"
+                variant="outline-secondary"
+                className="h-9 w-9"
+                onClick={(e) => { e.stopPropagation(); onPriority(); }}
+                aria-label="Change priority"
+                title="Change priority"
+            >
+                <ArrowUpDown size={16} />
+            </Button>
+            <Button
+                size="icon"
+                variant={item.disabled ? "outline-primary" : "outline-secondary"}
+                className="h-9 w-9"
+                onClick={(e) => { e.stopPropagation(); onToggle(); }}
+                aria-label={item.disabled ? "Enable rule" : "Disable rule"}
+                title={item.disabled ? "Enable rule" : "Disable rule"}
+            >
+                <Power size={16} />
+            </Button>
+        </div>
+    </div>
+);
 
 type RuleEditorOptions = {
     lists: string[];
@@ -123,68 +246,28 @@ function BypassComponent() {
             <RouteConfigCard resolvers={editorOptions.resolvers} />
             <RouteActivationProgress status={activation} onApplied={mutateActivation} />
             <CardList
+                density="compact"
                 items={data.items}
                 getKey={(v) => `${v.name}-${v.index}`}
                 renderListItem={(item) => (
-                    <div className="flex w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                        <div className="flex min-w-0 flex-1 items-start gap-3">
-                            <Badge variant="secondary" className="mt-1 shrink-0">#{item.index}</Badge>
-                            <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-ui-md bg-ui-primary-soft text-ui-primary">
-                                <Route size={18} />
-                            </div>
-                            <div className="min-w-0">
-                                <div className="flex min-w-0 flex-wrap items-center gap-2">
-                                    <span className="truncate font-semibold text-ui-heading">{item.name}</span>
-                                    <Badge variant="info">{item.mode}</Badge>
-                                    {item.disabled && <Badge variant="secondary">disabled</Badge>}
-                                </div>
-                                <div className="mt-1.5 flex min-w-0 flex-wrap gap-x-3 gap-y-1 text-xs text-ui-muted">
-                                    <span className="inline-flex min-w-0 items-center gap-1 whitespace-nowrap">
-                                        <span>Rules</span>
-                                        <span className="font-semibold text-ui-fg">{item.ruleCount}</span>
-                                    </span>
-                                    <span className="inline-flex min-w-0 items-center gap-1 whitespace-nowrap">
-                                        <span>Tag</span>
-                                        <span className="font-semibold text-ui-fg">{item.tag || "-"}</span>
-                                    </span>
-                                    <span className="inline-flex min-w-0 items-center gap-1 whitespace-nowrap">
-                                        <span>Resolver</span>
-                                        <span className="font-semibold text-ui-fg">{item.resolver || "-"}</span>
-                                    </span>
-                                </div>
-                            </div>
-                        </div>
-                        <div className="flex shrink-0 items-center gap-1.5 self-end sm:self-auto">
-                            <Button
-                                size="icon"
-                                variant="outline-secondary"
-                                className="h-9 w-9"
-                                onClick={(e) => { e.stopPropagation(); setPriorityItem(item); }}
-                                aria-label="Change priority"
-                                title="Change priority"
-                            >
-                                <ArrowUpDown size={16} />
-                            </Button>
-                            <Button
-                                size="icon"
-                                variant={item.disabled ? "outline-primary" : "outline-secondary"}
-                                className="h-9 w-9"
-                                onClick={(e) => { e.stopPropagation(); toggleDisabled(item); }}
-                                aria-label={item.disabled ? "Enable rule" : "Disable rule"}
-                                title={item.disabled ? "Enable rule" : "Disable rule"}
-                            >
-                                <Power size={16} />
-                            </Button>
-                        </div>
-                    </div>
+                    <RuleListItem
+                        item={item}
+                        onPriority={() => setPriorityItem(item)}
+                        onToggle={() => toggleDisabled(item)}
+                    />
                 )}
                 onClickItem={(item) => setEditing(item)}
                 header={
                     <div className="flex w-full flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
-                        <IconBox icon={Route} color="#3b82f6" title="Route Rules" description="Routing policy and matching order" />
+                        <IconBox
+                            icon={Route}
+                            tone="primary"
+                            title="Route Rules"
+                            description={`${data.page.total} rules · match from top to bottom`}
+                        />
                         <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:flex-nowrap">
                             {isValidating && <Spinner size="sm" />}
-                            <FilterSearch className="min-w-0 flex-1 sm:w-[180px] sm:flex-none" onEnter={(v) => { setPage(1); setQuery(v); }} size="sm" />
+                            <FilterSearch className="min-w-0 flex-1 sm:w-[200px] sm:flex-none" onEnter={(v) => { setPage(1); setQuery(v); }} size="sm" />
                             <Button size="sm" onClick={() => setCreating(true)}><Plus size={16} className="mr-1" /> Add</Button>
                         </div>
                     </div>
@@ -222,7 +305,7 @@ function RouteConfigCard({ resolvers }: { resolvers: string[] }) {
     return (
         <Card className="mb-4">
             <CardHeader>
-                <IconBox icon={ShieldCheck} color="#ec4899" title="Global Bypass Settings" description="DNS resolution and routing strategy" />
+                <IconBox icon={ShieldCheck} tone="danger" title="Global Bypass Settings" description="DNS resolution and routing strategy" />
             </CardHeader>
             <CardBody>
                 {error ? (
@@ -577,7 +660,7 @@ function RuleExprListEditor({ value, options, onChange }: { value: RuleExpr[]; o
 const OrSeparator = () => (
     <div className="my-4 flex items-center">
         <hr className="flex-grow opacity-25" />
-        <span className="mx-4 text-xs font-bold uppercase tracking-[1px] text-gray-500 dark:text-gray-400">Or</span>
+        <span className="mx-4 text-xs font-bold uppercase tracking-[1px] text-ui-muted">Or</span>
         <hr className="flex-grow opacity-25" />
     </div>
 );

--- a/src/docs/bypass/resolver/fakedns.tsx
+++ b/src/docs/bypass/resolver/fakedns.tsx
@@ -43,9 +43,9 @@ export const Fakedns: FC = () => {
     return (
         <Card className="h-full flex flex-col">
             <CardHeader className="flex justify-between items-center">
-                <IconBox icon={Wand2} color="#10b981" title='FakeDNS' description='Virtual IP Strategy' />
+                <IconBox icon={Wand2} tone="success" title='FakeDNS' description='Virtual IP Strategy' />
                 <div className="flex items-center gap-2">
-                    <span className="text-xs text-gray-500 dark:text-gray-400 font-medium">{data.enabled ? "ACTIVE" : "DISABLED"}</span>
+                    <span className="text-xs text-ui-muted font-medium">{data.enabled ? "ACTIVE" : "DISABLED"}</span>
                     <Switch
                         checked={data.enabled}
                         onCheckedChange={() => handleMutate(prev => ({ ...prev, enabled: !prev.enabled }))}

--- a/src/docs/bypass/resolver/hosts.tsx
+++ b/src/docs/bypass/resolver/hosts.tsx
@@ -43,7 +43,7 @@ export const Hosts: FC = () => {
     return (
         <Card className="h-full flex flex-col">
             <CardHeader>
-                <IconBox icon={Signpost} color="#3b82f6" title="Static Hosts" description="Local Domain Mappings" />
+                <IconBox icon={Signpost} tone="primary" title="Static Hosts" description="Local Domain Mappings" />
             </CardHeader>
             <CardBody className="flex-grow">
                 <div className="flex flex-col gap-4">
@@ -51,12 +51,12 @@ export const Hosts: FC = () => {
                         .sort(([a], [b]) => a.localeCompare(b))
                         .map(([k, v]) => (
                             <InputGroup key={"hosts" + k}>
-                                <InputGroupText className="font-mono text-xs px-2 flex-1 min-w-0 justify-start dark:bg-[#2b2b40] dark:text-[#a6a6c0] dark:border-gray-700">
+                                <InputGroupText className="font-mono text-xs px-2 flex-1 min-w-0 justify-start">
                                     <span className="truncate">{k}</span>
                                 </InputGroupText>
                                 <Input
                                     value={v}
-                                    className="font-mono text-blue-600 dark:text-blue-400 flex-[1.2] min-w-0"
+                                    className="font-mono text-ui-primary flex-[1.2] min-w-0"
                                     onChange={(e) => handleMutate(prev => ({
                                         ...prev,
                                         hosts: { ...prev.hosts, [k]: e.target.value }

--- a/src/docs/bypass/resolver/page.tsx
+++ b/src/docs/bypass/resolver/page.tsx
@@ -4,14 +4,25 @@ import { APIError } from "@/api/client";
 import { createResolver, deleteResolver, getResolver, listResolvers, saveResolver } from "@/api/resolvers";
 import { Badge } from '@/component/v2/badge';
 import { Button } from '@/component/v2/button';
-import { CardRowList, IconBox, MainContainer, SettingsBox } from '@/component/v2/card';
+import { Card, CardBody, CardFooter, CardHeader, IconBox, MainContainer, SettingsBox } from '@/component/v2/card';
 import { ConfirmModal } from "@/component/v2/confirm";
 import { SettingInputVertical, SettingSelectVertical, SwitchCard } from "@/component/v2/forms";
 import { Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, ModalTitle } from '@/component/v2/modal';
+import { Pagination } from "@/component/v2/pagination";
 import { Spinner } from '@/component/v2/spinner';
 import { GlobalToastContext } from '@/component/v2/toast';
 import { createDefaultResolver, normalizeResolver, Resolver, ResolverType } from "@/contract/resolver";
-import { Check, ChevronRight, Layers, Network, Plus, Trash } from 'lucide-react';
+import clsx from "clsx";
+import {
+    Check,
+    Globe2,
+    Layers,
+    Network,
+    Plus,
+    Shield,
+    Trash,
+} from 'lucide-react';
+import type { ElementType } from "react";
 import { FC, useContext, useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
 import Loading, { Error as ErrorDisplay } from "../../../component/v2/loading";
@@ -19,7 +30,7 @@ import { Fakedns } from "./fakedns";
 import { Hosts } from "./hosts";
 import { Server } from "./server";
 
-const PAGE_SIZE = 8;
+const PAGE_SIZE = 12;
 
 function errorOf(error: unknown): APIError | undefined {
     if (!error) return undefined;
@@ -29,37 +40,140 @@ function errorOf(error: unknown): APIError | undefined {
 
 const resolverTypes: ResolverType[] = ["udp", "tcp", "doh", "dot", "doq", "doh3", "system"];
 
-const ResolverItem: FC<{ item: Resolver }> = ({ item }) => {
+type BadgeVariant = "primary" | "secondary" | "success" | "danger" | "warning" | "info" | "muted";
+
+function resolverTypeVisual(type?: string): {
+    icon: ElementType;
+    tone: string;
+    soft: string;
+    badge: BadgeVariant;
+} {
+    switch ((type || "").toLowerCase()) {
+        case "doh":
+        case "doh3":
+            return {
+                icon: Globe2,
+                tone: "text-ui-info",
+                soft: "bg-ui-info-soft border-ui-info/15",
+                badge: "info",
+            };
+        case "dot":
+        case "doq":
+            return {
+                icon: Shield,
+                tone: "text-ui-success",
+                soft: "bg-ui-success-soft border-ui-success/15",
+                badge: "success",
+            };
+        case "tcp":
+            return {
+                icon: Network,
+                tone: "text-ui-warning",
+                soft: "bg-ui-warning-soft border-ui-warning/15",
+                badge: "warning",
+            };
+        case "udp":
+            return {
+                icon: Network,
+                tone: "text-ui-primary",
+                soft: "bg-ui-primary-soft border-ui-primary/15",
+                badge: "primary",
+            };
+        case "system":
+            return {
+                icon: Layers,
+                tone: "text-[var(--color-violet)]",
+                soft: "bg-[var(--color-violet-soft)] border-[color-mix(in_srgb,var(--color-violet)_18%,transparent)]",
+                badge: "secondary",
+            };
+        default:
+            return {
+                icon: Network,
+                tone: "text-ui-muted",
+                soft: "bg-ui-surface-muted border-ui-border",
+                badge: "muted",
+            };
+    }
+}
+
+function displayHost(item: Resolver) {
+    const host = (item.host || "").trim();
+    if (host) return host;
+    if (item.type === "system" || item.system) return "system default";
+    return "Not configured";
+}
+
+const ResolverTile: FC<{ item: Resolver; onClick: () => void }> = ({ item, onClick }) => {
+    const visual = resolverTypeVisual(item.type);
+    const Icon = visual.icon;
+    const host = displayHost(item);
+    const subnet = item.subnet?.trim();
+    const tls = item.tlsServerName?.trim();
+
     return (
-        <>
-            <div className="grid min-w-0 flex-1 gap-3 md:grid-cols-[minmax(190px,0.34fr)_minmax(0,1fr)] md:items-center">
-                <div className="flex min-w-0 items-center">
-                    <Network className="mr-4 shrink-0 text-ui-muted" size={20} />
-                    <div className="flex min-w-0 flex-wrap items-center gap-2">
-                        <span className="truncate font-medium">{item.id}</span>
-                        <Badge variant="info" className="shrink-0">{item.type}</Badge>
-                        {item.system && <Badge variant="primary" className="shrink-0">System</Badge>}
+        <button
+            type="button"
+            onClick={onClick}
+            className={clsx(
+                "group flex h-full min-h-[132px] w-full flex-col rounded-ui-lg border border-ui-border bg-ui-surface p-4 text-left",
+                "shadow-sm transition-[border-color,box-shadow,transform,background-color] duration-150",
+                "hover:-translate-y-0.5 hover:border-ui-primary/35 hover:bg-ui-surface-muted/40 hover:shadow-md",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ui-primary/35"
+            )}
+        >
+            <div className="flex items-start justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-3">
+                    <div className={clsx(
+                        "flex h-10 w-10 shrink-0 items-center justify-center rounded-ui-lg border",
+                        visual.soft,
+                        visual.tone
+                    )}>
+                        <Icon size={18} strokeWidth={1.9} />
                     </div>
-                </div>
-                <div className="grid min-w-0 gap-2 text-xs text-ui-muted sm:grid-cols-3">
                     <div className="min-w-0">
-                        <span className="mr-1 text-ui-muted/70">Host</span>
-                        <span className="truncate font-mono font-medium text-ui-fg">{item.host || "-"}</span>
-                    </div>
-                    <div className="min-w-0">
-                        <span className="mr-1 text-ui-muted/70">Subnet</span>
-                        <span className="truncate font-mono font-medium text-ui-fg">{item.subnet || "-"}</span>
-                    </div>
-                    <div className="min-w-0">
-                        <span className="mr-1 text-ui-muted/70">TLS</span>
-                        <span className="truncate font-mono font-medium text-ui-fg">{item.tlsServerName || "-"}</span>
+                        <div className="truncate text-[0.95rem] font-semibold text-ui-heading" title={item.id}>
+                            {item.id}
+                        </div>
+                        <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                            <Badge variant={visual.badge} pill className="px-2 py-0.5 text-[0.65rem] uppercase tracking-wide">
+                                {item.type}
+                            </Badge>
+                            {item.system && (
+                                <Badge variant="primary" pill className="px-2 py-0.5 text-[0.65rem]">
+                                    System
+                                </Badge>
+                            )}
+                        </div>
                     </div>
                 </div>
             </div>
-            <ChevronRight className="ml-2 shrink-0 text-ui-muted opacity-25" size={16} />
-        </>
-    )
-}
+
+            <div className="mt-4 min-w-0 flex-1">
+                <div className="text-[11px] font-medium uppercase tracking-wide text-ui-muted/80">Endpoint</div>
+                <div className="mt-1 break-all font-mono text-[12.5px] font-medium leading-relaxed text-ui-fg" title={host}>
+                    {host}
+                </div>
+            </div>
+
+            {(subnet || tls) && (
+                <div className="mt-3 flex flex-wrap gap-x-3 gap-y-1 border-t border-ui-border/70 pt-3 text-[11px] text-ui-muted">
+                    {subnet && (
+                        <span className="min-w-0">
+                            <span className="opacity-70">Subnet</span>{" "}
+                            <span className="font-mono font-medium text-ui-fg">{subnet}</span>
+                        </span>
+                    )}
+                    {tls && (
+                        <span className="min-w-0">
+                            <span className="opacity-70">TLS</span>{" "}
+                            <span className="font-mono font-medium text-ui-fg">{tls}</span>
+                        </span>
+                    )}
+                </div>
+            )}
+        </button>
+    );
+};
 
 export default function ResolverComponent() {
     return (
@@ -135,24 +249,43 @@ function ResolverList() {
             onDelete={(id) => setConfirmDelete({ show: true, id })}
         />
 
-        <CardRowList
-            layout="list"
-            paginated
-            pageSize={PAGE_SIZE}
-            currentPage={data.page.page || page}
-            totalItems={data.page.total}
-            onPageChange={setPage}
-            items={items}
-            getKey={(item) => item.id}
-            renderListItem={(item) => <ResolverItem item={item} />}
-            onClickItem={(item) => setShowdata({ show: true, id: item.id, new: false })}
-            header={
+        <Card density="compact" className="overflow-hidden">
+            <CardHeader>
                 <div className="flex w-full flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <IconBox icon={Layers} tone="primary" title='Resolvers' description='Upstream DNS Resolvers' />
-                    <Button size="sm" onClick={handleCreate}><Plus size={16} className="mr-1" /> Add</Button>
+                    <IconBox icon={Layers} tone="primary" title="Resolvers" description="Upstream DNS Resolvers" />
+                    <Button size="sm" onClick={handleCreate}>
+                        <Plus size={16} className="mr-1" /> Add
+                    </Button>
                 </div>
-            }
-        />
+            </CardHeader>
+            <CardBody density="compact">
+                {items.length === 0 ? (
+                    <div className="rounded-ui-lg border border-dashed border-ui-border px-4 py-10 text-center text-sm text-ui-muted">
+                        No resolvers yet. Add an upstream DNS endpoint to get started.
+                    </div>
+                ) : (
+                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                        {items.map((item) => (
+                            <ResolverTile
+                                key={item.id}
+                                item={item}
+                                onClick={() => setShowdata({ show: true, id: item.id, new: false })}
+                            />
+                        ))}
+                    </div>
+                )}
+            </CardBody>
+            {data.page.total > PAGE_SIZE && (
+                <CardFooter compact className="flex justify-center">
+                    <Pagination
+                        currentPage={data.page.page || page}
+                        totalItems={data.page.total}
+                        pageSize={data.page.pageSize || PAGE_SIZE}
+                        onPageChange={setPage}
+                    />
+                </CardFooter>
+            )}
+        </Card>
     </>
 }
 

--- a/src/docs/bypass/resolver/page.tsx
+++ b/src/docs/bypass/resolver/page.tsx
@@ -34,7 +34,7 @@ const ResolverItem: FC<{ item: Resolver }> = ({ item }) => {
         <>
             <div className="grid min-w-0 flex-1 gap-3 md:grid-cols-[minmax(190px,0.34fr)_minmax(0,1fr)] md:items-center">
                 <div className="flex min-w-0 items-center">
-                    <Network className="mr-4 shrink-0 text-gray-500 dark:text-gray-400" size={20} />
+                    <Network className="mr-4 shrink-0 text-ui-muted" size={20} />
                     <div className="flex min-w-0 flex-wrap items-center gap-2">
                         <span className="truncate font-medium">{item.id}</span>
                         <Badge variant="info" className="shrink-0">{item.type}</Badge>
@@ -56,7 +56,7 @@ const ResolverItem: FC<{ item: Resolver }> = ({ item }) => {
                     </div>
                 </div>
             </div>
-            <ChevronRight className="ml-2 shrink-0 text-gray-500 opacity-25 dark:text-gray-400" size={16} />
+            <ChevronRight className="ml-2 shrink-0 text-ui-muted opacity-25" size={16} />
         </>
     )
 }
@@ -148,7 +148,7 @@ function ResolverList() {
             onClickItem={(item) => setShowdata({ show: true, id: item.id, new: false })}
             header={
                 <div className="flex w-full flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
-                    <IconBox icon={Layers} color="#3b82f6" title='Resolvers' description='Upstream DNS Resolvers' />
+                    <IconBox icon={Layers} tone="primary" title='Resolvers' description='Upstream DNS Resolvers' />
                     <Button size="sm" onClick={handleCreate}><Plus size={16} className="mr-1" /> Add</Button>
                 </div>
             }

--- a/src/docs/bypass/resolver/server.tsx
+++ b/src/docs/bypass/resolver/server.tsx
@@ -39,7 +39,7 @@ export const Server: FC = () => {
     return (
         <Card className="flex flex-col">
             <CardHeader>
-                <IconBox icon={ServerIcon} color="#8b5cf6" title='DNS Server' description='Listen and Serve' />
+                <IconBox icon={ServerIcon} tone="violet" title='DNS Server' description='Listen and Serve' />
             </CardHeader>
             <CardBody className="p-6">
                 <SettingInputVertical

--- a/src/docs/bypass/tag/page.tsx
+++ b/src/docs/bypass/tag/page.tsx
@@ -268,7 +268,7 @@ function Tags() {
                 )}
                 header={
                     <div className="flex w-full flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
-                        <IconBox icon={TagsIcon} color="#8b5cf6" title="Tags Management" description={`${data.page.total} aliases and mirrors`} />
+                        <IconBox icon={TagsIcon} tone="violet" title="Tags Management" description={`${data.page.total} aliases and mirrors`} />
                         <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:flex-nowrap">
                             <FilterSearch className="min-w-0 flex-1 sm:w-[180px] sm:flex-none" onEnter={(v) => { setPage(1); setQuery(v); }} size="sm" />
                             <Button size="sm" onClick={() => setAdding(true)}><Plus size={16} className="mr-1" /> Add</Button>

--- a/src/docs/bypass/test/page.tsx
+++ b/src/docs/bypass/test/page.tsx
@@ -156,10 +156,10 @@ function Test() {
             {/* 1. Input Card */}
             <Card className="mb-4">
                 <CardHeader>
-                    <IconBox icon={Terminal} color="#f59e0b" title='Rule Testing' description='Simulate traffic to verify routing' />
+                    <IconBox icon={Terminal} tone="warning" title='Rule Testing' description='Simulate traffic to verify routing' />
                 </CardHeader>
                 <CardBody className="p-6">
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mb-6 px-1">
+                    <p className="text-xs text-ui-muted mb-6 px-1">
                         Enter a domain or IP address below to see which rule and outbound node would be selected.
                     </p>
                     <div className="flex gap-2">
@@ -186,7 +186,7 @@ function Test() {
                 testing && (
                     <div className="text-center py-12">
                         <Spinner size="md" className="mb-3" />
-                        <div className="text-gray-500 dark:text-gray-400 text-xs font-medium">Analyzing routing table...</div>
+                        <div className="text-ui-muted text-xs font-medium">Analyzing routing table...</div>
                     </div>
                 )
             }
@@ -196,7 +196,7 @@ function Test() {
                 resp && !testing &&
                 <Card className="animate-dataUpdate">
                     <CardHeader>
-                        <IconBox icon={ClipboardList} color="#10b981" title='Analysis Result' description='Raw decision path metadata' />
+                        <IconBox icon={ClipboardList} tone="success" title='Analysis Result' description='Raw decision path metadata' />
 
                         <Button
                             size="sm"
@@ -214,7 +214,7 @@ function Test() {
             }
 
             <div className="flex justify-center mt-6 opacity-50 pb-12">
-                <small className="text-gray-500 dark:text-gray-400 italic flex items-center">
+                <small className="text-ui-muted italic flex items-center">
                     <Info className="mr-1" size={14} />
                     This tool tests the core logic using the current active configuration.
                 </small>

--- a/src/docs/config/about/page.tsx
+++ b/src/docs/config/about/page.tsx
@@ -61,17 +61,17 @@ const InfoRow: FC<{
                 <div className="flex items-center gap-3 overflow-hidden">
                     <IconBoxRounded
                         icon={icon || LayoutGrid}
-                        color="#3b82f6"
+                        tone="primary"
                         className="flex-shrink-0 w-8 h-8 text-[0.9rem] border-none"
                     />
-                    <span className="text-gray-500 dark:text-gray-400 text-xs font-bold uppercase opacity-75 min-w-[90px] text-[0.7rem] tracking-[0.5px]">
+                    <span className="text-ui-muted text-xs font-bold uppercase opacity-75 min-w-[90px] text-[0.7rem] tracking-[0.5px]">
                         {label}
                     </span>
                 </div>
 
                 <div className="text-right overflow-hidden">
                     {url ? (
-                        <a href={url} target="_blank" rel="noreferrer" className="no-underline font-mono text-blue-500 truncate block">
+                        <a href={url} target="_blank" rel="noreferrer" className="no-underline font-mono text-ui-primary truncate block">
                             {value} <ExternalLink className="ml-1" size={12} />
                         </a>
                     ) : isBadge ?
@@ -160,7 +160,7 @@ export default function About() {
         <MainContainer className="flex flex-col">
             <Card className="order-2">
                 <CardHeader className="py-3">
-                    <IconBox icon={Info} color="#6366f1" title='System Information' description='Software version and build environment' />
+                    <IconBox icon={Info} tone="violet" title='System Information' description='Software version and build environment' />
                 </CardHeader>
 
                 <CardBody>
@@ -196,7 +196,7 @@ export default function About() {
                 {/* Build Tags / Features Section */}
                 {info.build && info.build.length > 0 && (
                     <CardFooter className="p-4 bg-transparent border-t border-gray-500/10">
-                        <SettingLabel className={"mb-2 block text-gray-500 dark:text-gray-400"}>Build Parameters</SettingLabel>
+                        <SettingLabel className={"mb-2 block text-ui-muted"}>Build Parameters</SettingLabel>
                         <div className="flex flex-wrap gap-2">
                             {info.build.map((tag, idx) => (
                                 <div key={idx} className="px-2 py-1 rounded border font-mono text-sm break-all dark:border-gray-700">
@@ -210,7 +210,7 @@ export default function About() {
 
             <Card className="order-1">
                 <CardHeader className="py-3">
-                    <IconBox icon={Rocket} color="#10b981" title="Software Update" description="Check GitHub Releases for a newer desktop build" />
+                    <IconBox icon={Rocket} tone="success" title="Software Update" description="Check GitHub Releases for a newer desktop build" />
                 </CardHeader>
                 <CardBody>
                     <div className="space-y-4">
@@ -292,7 +292,7 @@ export default function About() {
             </Card>
 
             <div className="order-3 text-center mt-4 opacity-50 pb-12">
-                <small className="text-gray-500 dark:text-gray-400">
+                <small className="text-ui-muted">
                     &copy; {new Date().getFullYear()} yuhaiin project. Distributed under MIT License.
                 </small>
             </div>

--- a/src/docs/config/backup/page.tsx
+++ b/src/docs/config/backup/page.tsx
@@ -75,7 +75,7 @@ function BackupPage() {
 
             <Card>
                 <CardHeader className="py-3">
-                    <IconBox icon={ShieldCheck} color="#3b82f6" title="Backup Instance" description="Identification and timing" />
+                    <IconBox icon={ShieldCheck} tone="primary" title="Backup Instance" description="Identification and timing" />
                 </CardHeader>
                 <CardBody>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -94,7 +94,7 @@ function BackupPage() {
                         <div className="md:col-span-2">
                             <SettingLabel>Last Backup Hash</SettingLabel>
                             <ListItem className="cursor-default bg-black/10 dark:bg-white/10">
-                                <Hash className="mr-2 text-gray-500 dark:text-gray-400" size={16} />
+                                <Hash className="mr-2 text-ui-muted" size={16} />
                                 <span className="font-mono text-sm truncate opacity-75">
                                     {data.lastBackupHash || "No backup records found"}
                                 </span>
@@ -173,7 +173,7 @@ function BackupPage() {
             </Card>
 
             <div className="text-center mt-3 opacity-50 pb-20">
-                <small className="text-gray-500 dark:text-gray-400">
+                <small className="text-ui-muted">
                     <Info className="mr-1 inline" size={14} />
                     Backups include all lists, rules, and node configurations.
                 </small>

--- a/src/docs/config/licenses/page.tsx
+++ b/src/docs/config/licenses/page.tsx
@@ -16,7 +16,7 @@ const LicenseItem: FC<{ item: License, index: number }> = ({ item, index }) => {
             <ListItem className="cursor-default">
                 <div className="flex items-center flex-grow overflow-hidden gap-3">
                     {/* Index or Icon */}
-                    <div className="bg-blue-500/10 text-blue-500 rounded-full flex items-center justify-center flex-shrink-0 w-8 h-8 text-[0.85rem] font-bold">
+                    <div className="bg-ui-primary-soft text-ui-primary rounded-full flex items-center justify-center flex-shrink-0 w-8 h-8 text-[0.85rem] font-bold">
                         {index + 1}
                     </div>
 
@@ -31,12 +31,12 @@ const LicenseItem: FC<{ item: License, index: number }> = ({ item, index }) => {
 
                         <div className="flex flex-col gap-1">
                             <a href={item.url} target="_blank" rel="noreferrer"
-                                className="flex items-center text-gray-500 dark:text-gray-400 text-sm no-underline font-mono opacity-75 hover:opacity-100 min-w-0">
+                                className="flex items-center text-ui-muted text-sm no-underline font-mono opacity-75 hover:opacity-100 min-w-0">
                                 <Link className="mr-1 shrink-0" size={14} />
                                 <span className="truncate">{item.url}</span>
                             </a>
                             <a href={item.licenseUrl} target="_blank" rel="noreferrer"
-                                className="flex items-center text-gray-500 dark:text-gray-400 text-sm no-underline font-mono opacity-75 min-w-0">
+                                className="flex items-center text-ui-muted text-sm no-underline font-mono opacity-75 min-w-0">
                                 <ShieldCheck className="mr-1 shrink-0" size={14} />
                                 <span className="truncate">License Source</span>
                             </a>
@@ -74,7 +74,7 @@ export default function Licenses() {
                     <div className="flex flex-col md:flex-row justify-between items-start md:items-center w-full gap-3">
                         <IconBox
                             icon={FileText}
-                            color="#10b981"
+                            tone="success"
                             title={`Open Source Licenses (${currentList.length})`}
                             description="Third-party credits and legal info"
                         />
@@ -106,7 +106,7 @@ export default function Licenses() {
             </Card>
 
             <div className="text-center mt-1 opacity-50">
-                <small className="text-gray-500 dark:text-gray-400">
+                <small className="text-ui-muted">
                     <Heart className="text-red-500 mr-1 inline" fill="currentColor" />
                     Built with love and open-source software.
                 </small>

--- a/src/docs/config/log/page.tsx
+++ b/src/docs/config/log/page.tsx
@@ -328,7 +328,7 @@ export default function LogComponent() {
                     <div className="flex justify-between items-center w-full gap-3">
                         <IconBox
                             icon={Terminal}
-                            color="#f59e0b"
+                            tone="warning"
                             title="Live Logcat"
                             description="Real-time system events"
                             className="!mr-3 !h-10 !w-10 !rounded-[10px]"
@@ -354,7 +354,7 @@ export default function LogComponent() {
                         </div>
                     )}
                 </CardHeader>
-                <CardBody className="!p-0 bg-gray-100 dark:bg-[#18181b] flex-1 min-h-0 overflow-hidden rounded-b-[inherit]">
+                <CardBody className="!p-0 bg-ui-surface-muted flex-1 min-h-0 overflow-hidden rounded-b-[inherit]">
                     <div className="h-full min-h-0 w-full rounded-[inherit] font-mono">
                         <VList
                             ref={logListRef}

--- a/src/docs/config/page.tsx
+++ b/src/docs/config/page.tsx
@@ -55,7 +55,7 @@ function ConfigComponent() {
         <MainContainer>
             <Card>
                 <CardHeader className="py-3">
-                    <IconBox icon={Globe} color="#3b82f6" title="General Settings" description="Network and system integration" />
+                    <IconBox icon={Globe} tone="primary" title="General Settings" description="Network and system integration" />
                 </CardHeader>
                 <CardBody>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -115,7 +115,7 @@ function ConfigComponent() {
 
             <Card>
                 <CardHeader className="py-3">
-                    <IconBox icon={NotebookText} color="#10b981" title="Logging (Logcat)" description="Debug and error reporting" />
+                    <IconBox icon={NotebookText} tone="success" title="Logging (Logcat)" description="Debug and error reporting" />
                 </CardHeader>
                 <CardBody>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -154,7 +154,7 @@ function ConfigComponent() {
 
             <Card>
                 <CardHeader className="py-3">
-                    <IconBox icon={Cpu} color="#f59e0b" title="Performance & Advanced" description="Buffer sizes and concurrency limits" />
+                    <IconBox icon={Cpu} tone="warning" title="Performance & Advanced" description="Buffer sizes and concurrency limits" />
                 </CardHeader>
                 <CardBody>
                     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/src/docs/connections/components.tsx
+++ b/src/docs/connections/components.tsx
@@ -97,6 +97,30 @@ function createFlow(raw: TotalFlow, prev?: Flow) {
     return new Flow(download, downloadRate, upload, uploadRate, raw.counters ?? {});
 }
 
+function countersUnchanged(a?: Record<string, Counter>, b?: Record<string, Counter>) {
+    if (a === b) return true;
+    if (!a || !b) return false;
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    if (aKeys.length !== bKeys.length) return false;
+    for (const key of aKeys) {
+        const prev = a[key];
+        const next = b[key];
+        if (!next) return false;
+        if (numberValue(prev?.download) !== numberValue(next.download)) return false;
+        if (numberValue(prev?.upload) !== numberValue(next.upload)) return false;
+    }
+    return true;
+}
+
+function flowUnchanged(prev: Flow | undefined, next: Flow) {
+    if (!prev) return false;
+    if (prev.download !== next.download || prev.upload !== next.upload) return false;
+    if (Math.abs(prev.downloadRate - next.downloadRate) > 0.5) return false;
+    if (Math.abs(prev.uploadRate - next.uploadRate) > 0.5) return false;
+    return countersUnchanged(prev.counters, next.counters);
+}
+
 export function useFlow(options?: UseFlowOptions) {
     const enabled = options?.enabled ?? true;
     const refreshInterval = options?.refreshInterval ?? 2000;
@@ -114,17 +138,41 @@ export function useFlow(options?: UseFlowOptions) {
 
         let stopped = false;
         let timer: ReturnType<typeof window.setTimeout> | undefined;
+        let visible = typeof document === "undefined" || document.visibilityState !== "hidden";
+
+        const clearTimer = () => {
+            if (timer !== undefined) {
+                window.clearTimeout(timer);
+                timer = undefined;
+            }
+        };
+
+        const schedule = () => {
+            clearTimer();
+            if (stopped || !visible) return;
+            timer = window.setTimeout(() => {
+                void poll();
+            }, refreshInterval);
+        };
 
         const poll = async () => {
-            setState(prev => ({ ...prev, isLoading: !prev.data, isValidating: true }));
+            if (stopped || !visible) return;
+            const firstLoad = !lastFlowRef.current;
+            if (firstLoad) {
+                setState(prev => ({ ...prev, isLoading: true, isValidating: true }));
+            }
             try {
                 const raw = await getTotalFlow();
-                if (stopped) return;
+                if (stopped || !visible) return;
                 const flow = createFlow(raw, lastFlowRef.current);
-                lastFlowRef.current = flow;
-                setState({ data: flow, isLoading: false, isValidating: false });
+                if (flowUnchanged(lastFlowRef.current, flow)) {
+                    lastFlowRef.current = flow;
+                } else {
+                    lastFlowRef.current = flow;
+                    setState({ data: flow, isLoading: false, isValidating: false, error: undefined });
+                }
             } catch (error) {
-                if (stopped) return;
+                if (stopped || !visible) return;
                 setState(prev => ({
                     ...prev,
                     error: errorText(error) ?? "failed to fetch flow",
@@ -132,14 +180,26 @@ export function useFlow(options?: UseFlowOptions) {
                     isValidating: false,
                 }));
             }
-            timer = window.setTimeout(poll, refreshInterval);
+            schedule();
         };
 
+        const onVisibility = () => {
+            visible = document.visibilityState !== "hidden";
+            if (visible) {
+                void poll();
+                return;
+            }
+            clearTimer();
+            setState(prev => ({ ...prev, isValidating: false }));
+        };
+
+        document.addEventListener("visibilitychange", onVisibility);
         void poll();
 
         return () => {
             stopped = true;
-            if (timer) window.clearTimeout(timer);
+            clearTimer();
+            document.removeEventListener("visibilitychange", onVisibility);
         };
     }, [enabled, refreshInterval]);
 
@@ -149,26 +209,41 @@ export function useFlow(options?: UseFlowOptions) {
     };
 }
 
-const MetricCard: FC<MetricProps & { accent?: "download" | "upload" | "neutral" }> = ({ label, value, error, accent = "neutral" }) => (
-    <div
-        className={clsx(
-            "relative flex min-h-[92px] flex-col justify-center overflow-hidden rounded-ui-xl border bg-[var(--metric-bg)] p-4 shadow-ui-card transition-colors",
-            "border-[var(--metric-border)] hover:border-ui-primary/25",
-            accent === "download" && "before:absolute before:inset-y-3 before:left-0 before:w-0.5 before:rounded-full before:bg-sky-500",
-            accent === "upload" && "before:absolute before:inset-y-3 before:left-0 before:w-0.5 before:rounded-full before:bg-emerald-500",
-        )}
-    >
-        <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--metric-label,#64748b)]">
-            {label}
+const MetricCard: FC<MetricProps & { accent?: "download" | "upload" | "neutral" }> = ({ label, value, error, accent = "neutral" }) => {
+    const display = error || value;
+    const prevRef = useRef(display);
+    const [pulse, setPulse] = useState(false);
+
+    useEffect(() => {
+        if (prevRef.current === display) return;
+        prevRef.current = display;
+        setPulse(true);
+        const timer = window.setTimeout(() => setPulse(false), 280);
+        return () => window.clearTimeout(timer);
+    }, [display]);
+
+    return (
+        <div
+            className={clsx(
+                "relative flex min-h-[92px] flex-col justify-center overflow-hidden rounded-ui-xl border bg-[var(--metric-bg)] p-4 shadow-ui-card transition-colors",
+                "border-[var(--metric-border)] hover:border-ui-primary/25",
+                accent === "download" && "before:absolute before:inset-y-3 before:left-0 before:w-0.5 before:rounded-full before:bg-ui-info",
+                accent === "upload" && "before:absolute before:inset-y-3 before:left-0 before:w-0.5 before:rounded-full before:bg-ui-success",
+            )}
+        >
+            <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--metric-label,#64748b)]">
+                {label}
+            </div>
+            <div className={clsx(
+                "truncate font-mono text-[1.35rem] font-bold leading-tight text-[var(--metric-value,#0f172a)]",
+                pulse && "animate-dataUpdate",
+                error && "text-ui-danger"
+            )}>
+                {display}
+            </div>
         </div>
-        <div className={clsx(
-            "animate-dataUpdate truncate font-mono text-[1.35rem] font-bold leading-tight text-[var(--metric-value,#0f172a)]",
-            error && "text-ui-danger"
-        )}>
-            {error || value}
-        </div>
-    </div>
-);
+    );
+};
 
 export const FlowCard: FC<{
     lastFlow?: Flow;
@@ -187,7 +262,6 @@ export const FlowCard: FC<{
                     ? "grid-cols-1 sm:grid-cols-2 xl:grid-cols-3"
                     : "grid-cols-1 sm:grid-cols-2 xl:grid-cols-4"
             )}
-            style={{ viewTransitionName: "flow-card-root !important" }}
         >
             <MetricCard accent="download" label={t("totalDownload")} value={lastFlow ? lastFlow.DownloadTotalString() : loading} error={flow_error} />
             <MetricCard accent="download" label={t("downloadRate")} value={lastFlow ? lastFlow.DownloadString() : loading} error={flow_error} />
@@ -332,10 +406,10 @@ const MatchHistoryItem: FC<{ value: MatchHistoryEntry[] }> = ({ value }) => {
                                     <div key={`${item.listName}-${itemIndex}`} className="flex items-center justify-between gap-3">
                                         <span className="notranslate break-all text-sm text-sidebar-color">{item.listName || "-"}</span>
                                         <div className="flex shrink-0 items-center gap-2">
-                                            <span className={clsx("text-xs font-medium", item.matched ? "text-green-500" : "text-sidebar-color opacity-70")}>
+                                            <span className={clsx("text-xs font-medium", item.matched ? "text-ui-success" : "text-sidebar-color opacity-70")}>
                                                 {item.matched ? label("Hit") : label("Miss")}
                                             </span>
-                                            <div className={clsx("flex h-6 w-6 items-center justify-center rounded-full", item.matched ? "bg-green-500/10 text-green-500" : "bg-white/5 text-ui-danger")}>
+                                            <div className={clsx("flex h-6 w-6 items-center justify-center rounded-full", item.matched ? "bg-ui-success-soft text-ui-success" : "bg-ui-surface-muted text-ui-danger")}>
                                                 {item.matched ? <Check size={14} /> : <X size={14} />}
                                             </div>
                                         </div>

--- a/src/docs/connections/components.tsx
+++ b/src/docs/connections/components.tsx
@@ -149,12 +149,22 @@ export function useFlow(options?: UseFlowOptions) {
     };
 }
 
-const MetricCard: FC<MetricProps> = ({ label, value, error }) => (
+const MetricCard: FC<MetricProps & { accent?: "download" | "upload" | "neutral" }> = ({ label, value, error, accent = "neutral" }) => (
     <div
-        className="grow basis-[calc(25%-1.25rem)] min-w-[200px] relative p-4 bg-[var(--metric-bg)] border border-[var(--metric-border)] rounded-2xl flex flex-col justify-center transition-all duration-300 ease-[cubic-bezier(0.4,0,0.2,1)] shadow-[0_4px_6px_-1px_rgba(0,0,0,0.1),0_2px_4px_-1px_rgba(0,0,0,0.06)] hover:-translate-y-[5px] hover:border-[rgba(99,102,241,0.3)] hover:shadow-[0_0_30px_rgba(99,102,241,0.1)]"
+        className={clsx(
+            "relative flex min-h-[92px] flex-col justify-center overflow-hidden rounded-ui-xl border bg-[var(--metric-bg)] p-4 shadow-ui-card transition-colors",
+            "border-[var(--metric-border)] hover:border-ui-primary/25",
+            accent === "download" && "before:absolute before:inset-y-3 before:left-0 before:w-0.5 before:rounded-full before:bg-sky-500",
+            accent === "upload" && "before:absolute before:inset-y-3 before:left-0 before:w-0.5 before:rounded-full before:bg-emerald-500",
+        )}
     >
-        <div className="text-xs uppercase tracking-wider text-[var(--metric-label,#64748b)] mb-1 font-semibold">{label}</div>
-        <div className={`text-[1.35rem] font-bold font-mono text-[var(--metric-value,#0f172a)] animate-dataUpdate ${error ? "text-red-500" : ""}`}>
+        <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-[var(--metric-label,#64748b)]">
+            {label}
+        </div>
+        <div className={clsx(
+            "animate-dataUpdate truncate font-mono text-[1.35rem] font-bold leading-tight text-[var(--metric-value,#0f172a)]",
+            error && "text-ui-danger"
+        )}>
             {error || value}
         </div>
     </div>
@@ -167,13 +177,22 @@ export const FlowCard: FC<{
 }> = ({ lastFlow, flow_error, extra_fields }) => {
     const { t } = useTranslation(["connections", "common"]);
     const loading = t("common:state.loading");
+    const hasExtra = Boolean(extra_fields?.length);
 
     return (
-        <div className="flex flex-wrap gap-3 w-full mb-3" style={{ viewTransitionName: "flow-card-root !important" }}>
-            <MetricCard label={t("totalDownload")} value={lastFlow ? lastFlow.DownloadTotalString() : loading} error={flow_error} />
-            <MetricCard label={t("downloadRate")} value={lastFlow ? lastFlow.DownloadString() : loading} error={flow_error} />
-            <MetricCard label={t("totalUpload")} value={lastFlow ? lastFlow.UploadTotalString() : loading} error={flow_error} />
-            <MetricCard label={t("uploadRate")} value={lastFlow ? lastFlow.UploadString() : loading} error={flow_error} />
+        <div
+            className={clsx(
+                "mb-3 grid w-full gap-3",
+                hasExtra
+                    ? "grid-cols-1 sm:grid-cols-2 xl:grid-cols-3"
+                    : "grid-cols-1 sm:grid-cols-2 xl:grid-cols-4"
+            )}
+            style={{ viewTransitionName: "flow-card-root !important" }}
+        >
+            <MetricCard accent="download" label={t("totalDownload")} value={lastFlow ? lastFlow.DownloadTotalString() : loading} error={flow_error} />
+            <MetricCard accent="download" label={t("downloadRate")} value={lastFlow ? lastFlow.DownloadString() : loading} error={flow_error} />
+            <MetricCard accent="upload" label={t("totalUpload")} value={lastFlow ? lastFlow.UploadTotalString() : loading} error={flow_error} />
+            <MetricCard accent="upload" label={t("uploadRate")} value={lastFlow ? lastFlow.UploadString() : loading} error={flow_error} />
             {extra_fields?.map((field, index) => (
                 <MetricCard key={`extra-field-${index}`} label={field.label} value={field.value || loading} error={field.error} />
             ))}
@@ -316,7 +335,7 @@ const MatchHistoryItem: FC<{ value: MatchHistoryEntry[] }> = ({ value }) => {
                                             <span className={clsx("text-xs font-medium", item.matched ? "text-green-500" : "text-sidebar-color opacity-70")}>
                                                 {item.matched ? label("Hit") : label("Miss")}
                                             </span>
-                                            <div className={clsx("flex h-6 w-6 items-center justify-center rounded-full", item.matched ? "bg-green-500/10 text-green-500" : "bg-white/5 text-red-500")}>
+                                            <div className={clsx("flex h-6 w-6 items-center justify-center rounded-full", item.matched ? "bg-green-500/10 text-green-500" : "bg-white/5 text-ui-danger")}>
                                                 {item.matched ? <Check size={14} /> : <X size={14} />}
                                             </div>
                                         </div>

--- a/src/docs/connections/failed/page.tsx
+++ b/src/docs/connections/failed/page.tsx
@@ -30,7 +30,7 @@ const ListItem: FC<{ data: FailedHistoryItem }> = React.memo(({ data }) => {
                     </div>
                     <div className="flex flex-col overflow-hidden" style={{ minWidth: 0 }}>
                         <span className="font-bold truncate text-base text-red-500/75">{data.host}</span>
-                        <small className="text-gray-500 dark:text-gray-400 truncate opacity-75 font-mono">
+                        <small className="text-ui-muted truncate opacity-75 font-mono">
                             {data.error || "Unknown Error"}
                         </small>
                     </div>
@@ -39,7 +39,7 @@ const ListItem: FC<{ data: FailedHistoryItem }> = React.memo(({ data }) => {
                     <IconBadge icon={Network} text={formatProtocolLabel(data.protocol)} color="info" />
                     <IconBadge icon={OctagonAlert} text={`${data.failedCount} Fails`} color="warning" />
                     <IconBadge icon={Clock} text={new Date(data.time).toLocaleTimeString()} color="secondary" />
-                    <div className="text-gray-500 dark:text-gray-400 opacity-25 ml-2 hidden md:block"><ChevronRight /></div>
+                    <div className="text-ui-muted opacity-25 ml-2 hidden md:block"><ChevronRight /></div>
                 </div>
             </div>
         </>
@@ -95,7 +95,7 @@ function FailedHistory() {
             <div className="flex flex-wrap justify-between items-end mb-4 gap-3">
                 <div>
                     <h4 className="font-bold mb-1">Failed Connections</h4>
-                    <div className="text-gray-500 dark:text-gray-400 flex items-center text-sm">
+                    <div className="text-ui-muted flex items-center text-sm">
                         <Bug className="text-red-500 mr-2" />
                         <span>Tracking {values.length} rejected or timed-out requests</span>
                     </div>

--- a/src/docs/connections/failed/page.tsx
+++ b/src/docs/connections/failed/page.tsx
@@ -127,6 +127,7 @@ function FailedHistory() {
 
             <CardList
                 items={paginatedItems}
+                animated={false}
                 getKey={(v) => `${v.host}-${v.time}`}
                 onClickItem={(item) => setInfo({ show: true, data: item })}
                 renderListItem={(item) => <ListItem data={item} />}

--- a/src/docs/connections/history/page.tsx
+++ b/src/docs/connections/history/page.tsx
@@ -14,8 +14,8 @@ import { ArrowDownWideNarrow, ArrowLeftRight, ChevronRight, Clock, Info, Radio, 
 import React, { FC, useMemo, useState } from "react"
 import useSWR from "swr"
 import Loading from "../../../component/v2/loading"
-import { ConnectionInfo } from "../components"
 import { NodeModal } from "../../node/modal"
+import { ConnectionInfo } from "../components"
 
 function formatProtocolLabel(value?: string) {
     if (!value) return "Unknown";
@@ -162,6 +162,7 @@ function History() {
 
             <CardList
                 items={paginatedItems}
+                animated={false}
                 getKey={(v) => `${v.connection.id}-${v.time}`}
                 onClickItem={(v) => setModalData({ show: true, data: v })}
                 renderListItem={(v) => <ListItem data={v} />}

--- a/src/docs/connections/history/page.tsx
+++ b/src/docs/connections/history/page.tsx
@@ -26,12 +26,12 @@ const ListItem: FC<{ data: AllHistory }> = React.memo(({ data }) => {
     return (
         <div className="flex min-w-0 w-full flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex min-w-0 w-full items-center gap-3 sm:w-auto sm:flex-1">
-                <div className="flex items-center justify-center bg-blue-500/10 text-blue-500 rounded-full shrink-0" style={{ width: "42px", height: "42px" }}>
+                <div className="flex items-center justify-center bg-ui-primary-soft text-ui-primary rounded-full shrink-0" style={{ width: "42px", height: "42px" }}>
                     {data.connection.network.connType.startsWith("udp") ? <Radio className="text-xl" /> : <ArrowLeftRight className="text-xl" />}
                 </div>
                 <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
                     <span className="truncate text-base font-bold" title={data.connection.addr}>{data.connection.addr || "-"}</span>
-                    <small className="truncate font-mono text-sm text-gray-500 opacity-75 dark:text-gray-400">
+                    <small className="truncate font-mono text-sm text-ui-muted opacity-75">
                         ID: #{data.connection.id} • {formatProtocolLabel(data.connection.network.connType)}
                     </small>
                 </div>
@@ -40,7 +40,7 @@ const ListItem: FC<{ data: AllHistory }> = React.memo(({ data }) => {
                 <IconBadge icon={ShieldCheck} text={formatProtocolLabel(data.connection.mode)} color="info" />
                 <IconBadge icon={RefreshCw} text={data.count} color="success" />
                 <IconBadge icon={Clock} text={new Date(data.time).toLocaleTimeString()} color="secondary" />
-                <div className="text-gray-500 dark:text-gray-400 opacity-25 ml-2 hidden md:block"><ChevronRight /></div>
+                <div className="text-ui-muted opacity-25 ml-2 hidden md:block"><ChevronRight /></div>
             </div>
         </div>
     );
@@ -114,7 +114,7 @@ function History() {
             <div className="flex flex-wrap justify-between items-end mb-4 gap-3">
                 <div>
                     <h4 className="font-bold mb-1">Connection History</h4>
-                    <div className="text-gray-500 dark:text-gray-400 flex items-center text-sm">
+                    <div className="text-ui-muted flex items-center text-sm">
                         <Info className="mr-2" />
                         <span>Showing {values.length} historical records</span>
                     </div>

--- a/src/docs/connections/v2/page.tsx
+++ b/src/docs/connections/v2/page.tsx
@@ -155,7 +155,7 @@ function Connections() {
             </div>
 
             {sorted.length === 0 ? (
-                <div className="p-6 mb-8 text-center text-gray-500 rounded-sidebar-radius border border-sidebar-border bg-sidebar-bg">
+                <div className="p-6 mb-8 text-center text-ui-muted rounded-sidebar-radius border border-sidebar-border bg-sidebar-bg">
                     No active connections.
                 </div>
             ) : sorted.length > 120 ? (
@@ -248,10 +248,10 @@ function ConnectionRow({ conn, counter, onSelect }: { conn: Connection; counter?
 function FlowBadge({ download, upload }: { download: string; upload: string }) {
     return (
         <div className="flex gap-2">
-            <span className="rounded-full flex items-center gap-1 px-2.5 py-0.5 text-xs font-medium bg-slate-100 text-slate-500 dark:bg-[#2b2b40] dark:text-[#a6a6c0]">
+            <span className="rounded-full flex items-center gap-1 px-2.5 py-0.5 text-xs font-medium bg-ui-chip text-ui-chip-fg">
                 <ArrowDown size={12} className="mr-1" />{download}
             </span>
-            <span className="rounded-full flex items-center gap-1 px-2.5 py-0.5 text-xs font-medium bg-slate-100 text-slate-500 dark:bg-[#2b2b40] dark:text-[#a6a6c0]">
+            <span className="rounded-full flex items-center gap-1 px-2.5 py-0.5 text-xs font-medium bg-ui-chip text-ui-chip-fg">
                 <ArrowUp size={12} className="mr-1" />{upload}
             </span>
         </div>

--- a/src/docs/connections/v2/page.tsx
+++ b/src/docs/connections/v2/page.tsx
@@ -13,13 +13,15 @@ import type { Connection, Connections, Counter } from "@/contract/connection";
 import { normalizeConnection } from "@/contract/connection";
 import { ArrowDown, ArrowUp, Network, Power, ShieldCheck, Tag } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useCallback, useContext, useEffect, useMemo, useState } from "react";
-import { VList } from "virtua";
+import { memo, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
-import { ConnectionInfo, FlowContainer, formatBytes, numberValue } from "../components";
+import { VList } from "virtua";
 import { NodeModal } from "../../node/modal";
+import { ConnectionInfo, FlowContainer, formatBytes, numberValue } from "../components";
 
 type SortBy = "id" | "name" | "download" | "upload";
+const VIRTUALIZE_THRESHOLD = 40;
+const ROW_HEIGHT = 52;
 
 function eventsURL() {
     const apiUrl = getApiUrl();
@@ -158,37 +160,45 @@ function Connections() {
                 <div className="p-6 mb-8 text-center text-ui-muted rounded-sidebar-radius border border-sidebar-border bg-sidebar-bg">
                     No active connections.
                 </div>
-            ) : sorted.length > 120 ? (
+            ) : sorted.length > VIRTUALIZE_THRESHOLD ? (
                 <div className="mb-8 overflow-hidden rounded-sidebar-radius border border-sidebar-border bg-sidebar-bg shadow-xl">
                     <VList
                         data={sorted}
-                        itemSize={82}
-                        bufferSize={820}
-                        style={{ height: "min(72vh, 900px)", width: "100%" }}
+                        itemSize={ROW_HEIGHT}
+                        bufferSize={ROW_HEIGHT * 10}
+                        style={{
+                            height: Math.min(
+                                sorted.length * ROW_HEIGHT,
+                                typeof window === "undefined" ? 720 : Math.min(window.innerHeight * 0.72, 900),
+                            ),
+                            width: "100%",
+                        }}
                     >
                         {(conn) => (
                             <ConnectionRow
                                 key={conn.id}
                                 conn={conn}
                                 counter={counters[conn.id]}
-                                onSelect={() => setSelected(conn)}
+                                onSelect={setSelected}
+                                animated={false}
                             />
                         )}
                     </VList>
                 </div>
             ) : (
-                <motion.div layout className="flex flex-col p-0 m-0 mb-8 overflow-hidden rounded-sidebar-radius border border-sidebar-border bg-sidebar-bg shadow-xl">
+                <div className="flex flex-col p-0 m-0 mb-8 overflow-hidden rounded-sidebar-radius border border-sidebar-border bg-sidebar-bg shadow-xl">
                     <AnimatePresence initial={false}>
                         {sorted.map(conn => (
                             <ConnectionRow
                                 key={conn.id}
                                 conn={conn}
                                 counter={counters[conn.id]}
-                                onSelect={() => setSelected(conn)}
+                                onSelect={setSelected}
+                                animated
                             />
                         ))}
                     </AnimatePresence>
-                </motion.div>
+                </div>
             )}
 
             <Modal open={selected !== undefined} onOpenChange={(open) => !open && setSelected(undefined)}>
@@ -218,44 +228,87 @@ function Connections() {
     );
 }
 
-function ConnectionRow({ conn, counter, onSelect }: { conn: Connection; counter?: Counter; onSelect: () => void }) {
+const ConnectionRow = memo(function ConnectionRow({
+    conn,
+    counter,
+    onSelect,
+    animated = true,
+}: {
+    conn: Connection;
+    counter?: Counter;
+    onSelect: (conn: Connection) => void;
+    animated?: boolean;
+}) {
+    const download = formatBytes(numberValue(counter?.download));
+    const upload = formatBytes(numberValue(counter?.upload));
+    // Keep everything in one dense row. Avoid 1fr/space-between — that creates a huge empty middle.
+    const className = "flex min-h-[52px] items-center gap-2.5 border-b border-sidebar-border px-3.5 py-2 transition-colors duration-150 cursor-pointer hover:bg-sidebar-hover last:border-b-0";
+    const handleClick = useCallback(() => onSelect(conn), [conn, onSelect]);
+
+    const body = (
+        <>
+            <code className="w-[3.25rem] shrink-0 font-mono text-[11px] tabular-nums text-sidebar-color/75">
+                {conn.id}
+            </code>
+
+            <span
+                className="min-w-0 max-w-[min(42vw,28rem)] shrink truncate text-[0.9rem] font-medium leading-5 text-ui-heading"
+                title={conn.addr}
+            >
+                {conn.addr}
+            </span>
+
+            <div className="flex min-w-0 shrink-0 flex-wrap items-center gap-1.5">
+                <IconBadge icon={ShieldCheck} text={conn.mode || "unknown"} />
+                <IconBadge icon={Network} text={conn.network.connType || "unknown"} />
+                {conn.tag && <IconBadge icon={Tag} text={conn.tag} />}
+            </div>
+
+            <FlowBadge download={download} upload={upload} />
+        </>
+    );
+
+    if (!animated) {
+        return (
+            <div className={className} onClick={handleClick}>
+                {body}
+            </div>
+        );
+    }
+
     return (
         <motion.div
-            layout
-            initial={{ opacity: 0, y: 8 }}
+            initial={{ opacity: 0, y: 6 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, height: 0 }}
-            transition={{ duration: 0.18, ease: "easeOut" }}
-            className="flex flex-col items-start md:flex-row md:justify-between px-4 py-3 border-b border-sidebar-border transition-[background,box-shadow,transform] duration-200 cursor-pointer hover:bg-sidebar-hover hover:shadow-ui-card hover:-translate-y-[1px] last:border-b-0"
-            onClick={onSelect}
+            transition={{ duration: 0.16, ease: "easeOut" }}
+            className={className}
+            onClick={handleClick}
         >
-            <div className="flex min-w-0 flex-col">
-                <code className="font-mono text-xs text-sidebar-color">{conn.id}</code>
-                <span className="font-medium text-md truncate">{conn.addr}</span>
-            </div>
-            <div className="flex flex-col items-start gap-2 md:items-end md:mt-0">
-                <FlowBadge download={formatBytes(numberValue(counter?.download))} upload={formatBytes(numberValue(counter?.upload))} />
-                <div className="flex gap-2 items-center flex-wrap text-xs md:mt-0">
-                    <IconBadge icon={ShieldCheck} text={conn.mode || "unknown"} />
-                    <IconBadge icon={Network} text={conn.network.connType || "unknown"} />
-                    {conn.tag && <IconBadge icon={Tag} text={conn.tag} />}
-                </div>
-            </div>
+            {body}
         </motion.div>
     );
-}
+}, (prev, next) => (
+    prev.conn === next.conn
+    && prev.animated === next.animated
+    && prev.onSelect === next.onSelect
+    && numberValue(prev.counter?.download) === numberValue(next.counter?.download)
+    && numberValue(prev.counter?.upload) === numberValue(next.counter?.upload)
+));
 
-function FlowBadge({ download, upload }: { download: string; upload: string }) {
+const FlowBadge = memo(function FlowBadge({ download, upload }: { download: string; upload: string }) {
     return (
-        <div className="flex gap-2">
-            <span className="rounded-full flex items-center gap-1 px-2.5 py-0.5 text-xs font-medium bg-ui-chip text-ui-chip-fg">
-                <ArrowDown size={12} className="mr-1" />{download}
+        <div className="inline-flex shrink-0 items-center gap-2 text-[11px] font-semibold tabular-nums">
+            <span className="inline-flex items-center gap-0.5 text-ui-info">
+                <ArrowDown size={11} />
+                {download}
             </span>
-            <span className="rounded-full flex items-center gap-1 px-2.5 py-0.5 text-xs font-medium bg-ui-chip text-ui-chip-fg">
-                <ArrowUp size={12} className="mr-1" />{upload}
+            <span className="inline-flex items-center gap-0.5 text-ui-success">
+                <ArrowUp size={11} />
+                {upload}
             </span>
         </div>
     );
-}
+});
 
 export default Connections;

--- a/src/docs/group/activates/page.tsx
+++ b/src/docs/group/activates/page.tsx
@@ -19,18 +19,18 @@ const ActiveNodeItem: FC<{ v: Node, onClose: () => void }> = ({ v, onClose }) =>
             <div className="flex items-center flex-grow overflow-hidden gap-3 w-full md:w-auto">
                 <IconBoxRounded
                     icon={Zap}
-                    color="#198754"
+                    tone="success"
                     className="flex-shrink-0"
                     style={{ width: "40px", height: "40px", marginRight: "0px", border: "none" }}
                 />
                 <div className="flex flex-col overflow-hidden min-w-0">
                     <div className="flex items-center gap-2 mb-1">
                         <span className="font-bold truncate text-base">{v.name}</span>
-                        <Badge className="bg-opacity-10 text-blue-600 border border-blue-600 border-opacity-25 px-2 py-1" style={{ fontSize: "0.65rem" }}>
+                        <Badge className="bg-ui-primary-soft text-ui-primary border border-ui-primary/25 px-2 py-1" style={{ fontSize: "0.65rem" }}>
                             {v.group}
                         </Badge>
                     </div>
-                    <small className="text-gray-500 truncate font-mono opacity-75 text-sm">
+                    <small className="text-ui-muted truncate font-mono opacity-75 text-sm">
                         <Hash className="mr-1 inline" size={12} />{v.id}
                     </small>
                 </div>
@@ -88,7 +88,7 @@ function Activates({ showFooter = true }: { showFooter?: boolean }) {
                 title={
                     <div className="py-2">
                         <p className="mb-1">Are you sure you want to <strong>terminate</strong> this active node connection?</p>
-                        <code className="text-sm text-gray-500 font-mono">{confirmData.id}</code>
+                        <code className="text-sm text-ui-muted font-mono">{confirmData.id}</code>
                     </div>
                 }
                 onHide={() => setConfirmData(prev => ({ ...prev, show: false }))}
@@ -101,7 +101,7 @@ function Activates({ showFooter = true }: { showFooter?: boolean }) {
                 onClickItem={(v) => setNodeModal({ show: true, node: v })}
                 header={
                     <div className="flex items-center justify-between w-full">
-                        <IconBox icon={Activity} color="#198754" title="Active Nodes" description="Live outbound connection instances" />
+                        <IconBox icon={Activity} tone="success" title="Active Nodes" description="Live outbound connection instances" />
                         <Badge variant="success" className="bg-opacity-10 text-green-600 border border-green-600 border-opacity-25 px-3 py-2 rounded-full">
                             {sortedNodes.length} Running
                         </Badge>
@@ -111,7 +111,7 @@ function Activates({ showFooter = true }: { showFooter?: boolean }) {
 
             {showFooter &&
                 <div className="text-center mt-4 opacity-50 pb-5">
-                    <small className="text-gray-500 text-sm flex items-center justify-center">
+                    <small className="text-ui-muted text-sm flex items-center justify-center">
                         <Info className="mr-1" size={16} />
                         Closing a node here will force a reconnection if the rule still requires it.
                     </small>

--- a/src/docs/group/activates/page.tsx
+++ b/src/docs/group/activates/page.tsx
@@ -54,7 +54,11 @@ const ActiveNodeItem: FC<{ v: Node, onClose: () => void }> = ({ v, onClose }) =>
 
 function Activates({ showFooter = true }: { showFooter?: boolean }) {
     const ctx = useContext(GlobalToastContext);
-    const { data, error, isLoading, mutate } = useSWR("/api/v2/nodes/active", activeNodes);
+    const { data, error, isLoading, mutate } = useSWR("/api/v2/nodes/active", activeNodes, {
+        revalidateOnFocus: false,
+        // Home embeds this list under live traffic work; refresh less aggressively there.
+        refreshInterval: showFooter ? 0 : 15000,
+    });
     const [confirmData, setConfirmData] = useState({ show: false, id: "" });
     const [nodeModal, setNodeModal] = useState<{ show: boolean; node?: Node }>({ show: false });
 
@@ -97,12 +101,13 @@ function Activates({ showFooter = true }: { showFooter?: boolean }) {
 
             <CardList
                 items={sortedNodes}
+                animated={false}
                 renderListItem={(v) => <ActiveNodeItem v={v} onClose={() => setConfirmData({ show: true, id: v.id })} />}
                 onClickItem={(v) => setNodeModal({ show: true, node: v })}
                 header={
                     <div className="flex items-center justify-between w-full">
                         <IconBox icon={Activity} tone="success" title="Active Nodes" description="Live outbound connection instances" />
-                        <Badge variant="success" className="bg-opacity-10 text-green-600 border border-green-600 border-opacity-25 px-3 py-2 rounded-full">
+                        <Badge variant="success" className="bg-ui-success-soft text-ui-success border border-ui-success/25 px-3 py-2 rounded-full">
                             {sortedNodes.length} Running
                         </Badge>
                     </div>

--- a/src/docs/group/page.tsx
+++ b/src/docs/group/page.tsx
@@ -30,11 +30,15 @@ import type { Node, NodeLatencyResponse } from "@/contract/node";
 import { normalizeNode } from "@/contract/node";
 import clsx from "clsx";
 import { Check, ChevronDown, Gauge, Layers, Network, Plus, Power, Search, Upload } from "lucide-react";
-import { FC, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+import { FC, memo, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
 import useSWR from "swr";
 import { useLocalStorage } from "usehooks-ts";
+import { VList } from "virtua";
 import Loading, { Error as ErrorDisplay } from "../../component/v2/loading";
 import { NodeModal } from "../node/modal";
+
+const LATENCY_STORAGE_LIMIT = 500;
+const GROUP_VIRTUALIZE_THRESHOLD = 60;
 
 function errorOf(error: unknown): APIError | undefined {
     if (!error) return undefined;
@@ -327,6 +331,23 @@ const GroupPicker: FC<{
     );
 };
 
+function pruneLatencyMap(
+    current: Record<string, NodeLatencyState>,
+    keepIds: Iterable<string>,
+    limit = LATENCY_STORAGE_LIMIT,
+): Record<string, NodeLatencyState> {
+    const keep = new Set(keepIds);
+    const next: Record<string, NodeLatencyState> = {};
+    for (const id of keep) {
+        if (current[id]) next[id] = current[id];
+    }
+    if (Object.keys(next).length <= limit) return next;
+
+    const entries = Object.entries(next);
+    entries.sort(([a], [b]) => a.localeCompare(b));
+    return Object.fromEntries(entries.slice(-limit));
+}
+
 const NodeItem: FC<{
     item: Node;
     onUse: () => void;
@@ -334,7 +355,7 @@ const NodeItem: FC<{
     onEdit: () => void;
     latency?: NodeLatencyState;
     busy?: Partial<Record<NodeLatencyType, boolean>>;
-}> = ({ item, onUse, onLatency, onEdit, latency, busy }) => {
+}> = memo(({ item, onUse, onLatency, onEdit, latency, busy }) => {
     const chain = chainLabel(item);
     const hasLatency = Boolean(busy?.tcp || busy?.udp || !isEmptyLatency(latency?.tcp) || !isEmptyLatency(latency?.udp));
     const hasIp = Boolean(busy?.ip || latency?.ip);
@@ -471,7 +492,7 @@ const NodeItem: FC<{
             </AccordionContent>
         </AccordionItem>
     );
-};
+});
 
 const NodeImportModal: FC<{
     show: boolean;
@@ -617,6 +638,14 @@ export default function Group() {
         if (!selectedGroup && groups.length > 0) setSelectedGroup(groups[0]);
     }, [groups, selectedGroup]);
 
+    useEffect(() => {
+        if (items.length === 0) return;
+        setLatency((prev) => {
+            const next = pruneLatencyMap(prev, items.map((item) => item.id));
+            return Object.keys(next).length === Object.keys(prev).length ? prev : next;
+        });
+    }, [items, setLatency]);
+
     if (apiError) return <ErrorDisplay statusCode={apiError.code} title={apiError.msg} raw={errorRaw(apiError.raw)} />;
     if (isLoading || data === undefined) return <Loading />;
 
@@ -658,12 +687,18 @@ export default function Group() {
             ipv6: latencyIPv6,
         })
             .then((result) => {
-                setLatency((prev) => ({ ...prev, [id]: { ...prev[id], [type]: latencyResultValue(result) } }));
+                setLatency((prev) => pruneLatencyMap(
+                    { ...prev, [id]: { ...prev[id], [type]: latencyResultValue(result) } },
+                    items.map((item) => item.id),
+                ));
                 if (!result.ok) ctx.Error(result.error ?? "Latency failed");
             })
             .catch((err: unknown) => {
                 const apiErr = errorOf(err);
-                setLatency((prev) => ({ ...prev, [id]: { ...prev[id], [type]: "error" } }));
+                setLatency((prev) => pruneLatencyMap(
+                    { ...prev, [id]: { ...prev[id], [type]: "error" } },
+                    items.map((item) => item.id),
+                ));
                 ctx.Error(apiErr?.msg ?? "Latency failed");
             })
             .finally(() => setBusyLatency((prev) => ({ ...prev, [id]: { ...prev[id], [type]: false } })));
@@ -763,6 +798,31 @@ export default function Group() {
                                                 : "Add a node to this group to see it here."}
                                         </div>
                                     </div>
+                                ) : groupItems.length > GROUP_VIRTUALIZE_THRESHOLD ? (
+                                    <VList
+                                        data={groupItems}
+                                        itemSize={72}
+                                        bufferSize={720}
+                                        style={{ height: "min(72vh, 900px)", width: "100%" }}
+                                    >
+                                        {(item) => (
+                                            <Accordion
+                                                key={item.id}
+                                                type="single"
+                                                collapsible
+                                                className="!mb-0 !rounded-none !border-0 !shadow-none !transition-none hover:!translate-y-0 hover:!border-transparent hover:!shadow-none"
+                                            >
+                                                <NodeItem
+                                                    item={item}
+                                                    latency={latency[item.id]}
+                                                    busy={busyLatency[item.id]}
+                                                    onUse={() => handleUse(item.id)}
+                                                    onLatency={(type) => handleLatency(item.id, type)}
+                                                    onEdit={() => setShowdata({ show: true, id: item.id, new: false })}
+                                                />
+                                            </Accordion>
+                                        )}
+                                    </VList>
                                 ) : (
                                     <Accordion
                                         type="single"

--- a/src/docs/group/page.tsx
+++ b/src/docs/group/page.tsx
@@ -2,17 +2,6 @@
 
 import { APIError } from "@/api/client";
 import { createNode, deleteNode, latencyNode, listNodes, useNode as selectNode, type NodeLatencyType } from "@/api/nodes";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/component/v2/accordion";
-import { Badge } from "@/component/v2/badge";
-import { Button } from "@/component/v2/button";
-import { Card, CardBody, CardHeader, MainContainer } from "@/component/v2/card";
-import { Dropdown, DropdownContent, DropdownItem, DropdownTrigger } from "@/component/v2/dropdown";
-import { Textarea } from "@/component/v2/input";
-import { Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, ModalTitle } from "@/component/v2/modal";
-import { Spinner } from "@/component/v2/spinner";
-import { GlobalToastContext } from "@/component/v2/toast";
-import type { Node, NodeLatencyResponse } from "@/contract/node";
-import { normalizeNode } from "@/contract/node";
 import {
     LatencyDNSUrlDefault,
     LatencyDNSUrlKey,
@@ -22,14 +11,26 @@ import {
     LatencyIPUrlKey,
     LatencyIPv6Default,
     LatencyIPv6Key,
-    normalizeLatencyDNSUrl,
     LatencyStunTCPUrlDefault,
     LatencyStunTCPUrlKey,
     LatencyStunUrlDefault,
     LatencyStunUrlKey,
+    normalizeLatencyDNSUrl,
 } from "@/common/apiurl";
-import { Check, ChevronDown, Gauge, Network, Plus, Power, Upload } from "lucide-react";
-import { FC, useContext, useEffect, useMemo, useState } from "react";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/component/v2/accordion";
+import { Badge } from "@/component/v2/badge";
+import { Button } from "@/component/v2/button";
+import { Card, CardBody, CardHeader, IconBox, MainContainer } from "@/component/v2/card";
+import { Dropdown, DropdownContent, DropdownItem, DropdownTrigger } from "@/component/v2/dropdown";
+import { Input, Textarea } from "@/component/v2/input";
+import { Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, ModalTitle } from "@/component/v2/modal";
+import { Spinner } from "@/component/v2/spinner";
+import { GlobalToastContext } from "@/component/v2/toast";
+import type { Node, NodeLatencyResponse } from "@/contract/node";
+import { normalizeNode } from "@/contract/node";
+import clsx from "clsx";
+import { Check, ChevronDown, Gauge, Layers, Network, Plus, Power, Search, Upload } from "lucide-react";
+import { FC, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
 import useSWR from "swr";
 import { useLocalStorage } from "usehooks-ts";
 import Loading, { Error as ErrorDisplay } from "../../component/v2/loading";
@@ -149,25 +150,182 @@ function latencyResultValue(result: NodeLatencyResponse): NodeLatencyValue {
     return "ok";
 }
 
-const LatencyInfo: FC<{
-    label: string;
-    value: NodeLatencyValue | undefined;
-    loading?: boolean;
-}> = ({ label, value, loading }) => (
-    <div className="rounded-ui-sm bg-ui-surface px-3 py-2.5">
-        <div className="mb-1 text-xs font-medium text-ui-muted/70">{label}</div>
-        <div className="flex min-h-5 items-center text-sm font-medium">
-            {loading ? <Spinner size="sm" /> : <span className={`break-all ${latencyTextClass(value)}`}>{latencyText(value)}</span>}
+const NodeLatencyBadge: FC<{ type: typeof collapsedLatencyTypes[number]; value: NodeLatencyValue | undefined; loading?: boolean }> = ({ type, value, loading }) => {
+    if (!value && !loading) return null;
+    return (
+        <Badge variant={loading ? "secondary" : latencyVariant(value)} pill className="gap-1 px-2 py-0.5 font-medium">
+            <span className="text-[0.62rem] font-semibold uppercase tracking-wide opacity-70">{type}</span>
+            {loading ? <Spinner size="sm" /> : <span className="font-mono text-[0.72rem]">{latencyText(value)}</span>}
+        </Badge>
+    );
+};
+
+function isEmptyLatency(value: NodeLatencyValue | undefined): boolean {
+    if (value === undefined || value === null) return true;
+    if (typeof value === "string") {
+        const normalized = value.trim().toLowerCase();
+        return !normalized || normalized === "n/a" || normalized === "該当なし";
+    }
+    return false;
+}
+
+const ResultChip: FC<{ label: string; value: NodeLatencyValue | undefined; loading?: boolean }> = ({ label, value, loading }) => {
+    if (!loading && isEmptyLatency(value)) return null;
+    return (
+        <div className="inline-flex min-w-0 max-w-full items-center gap-2 rounded-full border border-ui-border/80 bg-ui-bg px-3 py-1.5">
+            <span className="shrink-0 text-[11px] font-medium uppercase tracking-wide text-ui-muted">{label}</span>
+            {loading
+                ? <Spinner size="sm" />
+                : <span className={clsx("truncate text-sm font-semibold font-mono", latencyTextClass(value))}>{latencyText(value)}</span>}
         </div>
+    );
+};
+
+const ResultRow: FC<{ label: string; value: NodeLatencyValue | undefined; loading?: boolean }> = ({ label, value, loading }) => {
+    if (!loading && isEmptyLatency(value)) return null;
+    return (
+        <div className="flex min-w-0 items-start gap-3 rounded-ui-md border border-ui-border/70 bg-ui-bg/80 px-3 py-2">
+            <span className="mt-0.5 w-16 shrink-0 text-[11px] font-medium uppercase tracking-wide text-ui-muted">{label}</span>
+            {loading
+                ? <Spinner size="sm" className="mt-0.5" />
+                : (
+                    <span className={clsx("min-w-0 break-all text-sm font-medium font-mono leading-snug", latencyTextClass(value))}>
+                        {latencyText(value)}
+                    </span>
+                )}
+        </div>
+    );
+};
+
+const ResultGroup: FC<{ title: string; children: ReactNode }> = ({ title, children }) => (
+    <div className="min-w-0 space-y-2">
+        <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-ui-muted">{title}</div>
+        <div className="space-y-2">{children}</div>
     </div>
 );
 
-const NodeLatencyBadge: FC<{ type: typeof collapsedLatencyTypes[number]; value: NodeLatencyValue | undefined }> = ({ type, value }) => (
-    <Badge variant={latencyVariant(value)} className="gap-1 px-2 py-1 font-medium">
-        <span className="text-[0.68rem] opacity-70">{type.toUpperCase()}</span>
-        <span className="font-mono">{latencyText(value)}</span>
-    </Badge>
-);
+const CHIP_GROUP_LIMIT = 6;
+
+const GroupPicker: FC<{
+    groups: string[];
+    counts: Map<string, number>;
+    value: string;
+    onChange: (group: string) => void;
+}> = ({ groups, counts, value, onChange }) => {
+    const [open, setOpen] = useState(false);
+    const [filter, setFilter] = useState("");
+
+    useEffect(() => {
+        if (!open) setFilter("");
+    }, [open]);
+
+    if (groups.length <= CHIP_GROUP_LIMIT) {
+        return (
+            <div className="flex min-w-0 flex-1 flex-wrap gap-2">
+                {groups.map((group) => {
+                    const active = group === value;
+                    const count = counts.get(group) ?? 0;
+                    return (
+                        <button
+                            key={group}
+                            type="button"
+                            onClick={() => onChange(group)}
+                            className={clsx(
+                                "inline-flex max-w-full items-center gap-2 rounded-full border px-3.5 py-1.5 text-sm font-medium transition-colors",
+                                active
+                                    ? "border-ui-primary bg-ui-primary-soft text-ui-primary shadow-inner-subtle"
+                                    : "border-ui-border bg-ui-surface text-ui-muted hover:border-ui-primary/30 hover:bg-ui-hover hover:text-ui-fg"
+                            )}
+                        >
+                            <span className="truncate">{group}</span>
+                            <span className={clsx(
+                                "rounded-full px-1.5 py-0.5 text-[11px] font-semibold",
+                                active ? "bg-ui-primary/15 text-ui-primary" : "bg-ui-chip text-ui-chip-fg"
+                            )}>
+                                {count}
+                            </span>
+                        </button>
+                    );
+                })}
+            </div>
+        );
+    }
+
+    const filtered = filter.trim()
+        ? groups.filter((group) => group.toLowerCase().includes(filter.trim().toLowerCase()))
+        : groups;
+    const selectedCount = counts.get(value) ?? 0;
+
+    return (
+        <Dropdown open={open} onOpenChange={setOpen}>
+            <DropdownTrigger asChild>
+                <Button
+                    type="button"
+                    variant="outline-secondary"
+                    className="h-9 min-w-0 max-w-full justify-between gap-2 px-3 text-sm font-medium lg:min-w-[240px] lg:max-w-[360px]"
+                >
+                    <span className="flex min-w-0 items-center gap-2">
+                        <Layers size={15} className="shrink-0 opacity-70" />
+                        <span className="truncate">{value || "Select group"}</span>
+                    </span>
+                    <span className="flex shrink-0 items-center gap-1.5">
+                        {value && (
+                            <span className="rounded-full bg-ui-chip px-1.5 py-0.5 text-[11px] font-semibold text-ui-chip-fg">
+                                {selectedCount}
+                            </span>
+                        )}
+                        <ChevronDown size={14} className="opacity-60" />
+                    </span>
+                </Button>
+            </DropdownTrigger>
+            <DropdownContent
+                align="start"
+                className="min-w-[min(320px,calc(100vw-2rem))] w-[var(--radix-dropdown-menu-trigger-width)] max-w-[min(420px,calc(100vw-2rem))]"
+            >
+                <div
+                    className="sticky top-0 z-10 border-b border-ui-border bg-ui-surface px-2 pb-2 pt-1"
+                    onKeyDown={(e) => e.stopPropagation()}
+                    onPointerDown={(e) => e.stopPropagation()}
+                >
+                    <div className="relative">
+                        <Search size={14} className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-ui-muted" />
+                        <Input
+                            value={filter}
+                            onChange={(e) => setFilter(e.target.value)}
+                            placeholder="Filter groups..."
+                            className="h-8 pl-8 text-sm"
+                            autoFocus
+                        />
+                    </div>
+                </div>
+                {filtered.length === 0 ? (
+                    <div className="px-3 py-4 text-center text-xs text-ui-muted">No matching groups</div>
+                ) : (
+                    filtered.map((group) => {
+                        const active = group === value;
+                        const count = counts.get(group) ?? 0;
+                        return (
+                            <DropdownItem
+                                key={group}
+                                className={clsx("gap-2", active && "bg-ui-primary-soft text-ui-primary")}
+                                onSelect={() => onChange(group)}
+                            >
+                                <span className="min-w-0 flex-1 truncate font-medium">{group}</span>
+                                <span className={clsx(
+                                    "rounded-full px-1.5 py-0.5 text-[11px] font-semibold",
+                                    active ? "bg-ui-primary/15 text-ui-primary" : "bg-ui-chip text-ui-chip-fg"
+                                )}>
+                                    {count}
+                                </span>
+                                {active && <Check size={14} className="shrink-0 text-ui-primary" />}
+                            </DropdownItem>
+                        );
+                    })
+                )}
+            </DropdownContent>
+        </Dropdown>
+    );
+};
 
 const NodeItem: FC<{
     item: Node;
@@ -176,102 +334,144 @@ const NodeItem: FC<{
     onEdit: () => void;
     latency?: NodeLatencyState;
     busy?: Partial<Record<NodeLatencyType, boolean>>;
-}> = ({ item, onUse, onLatency, onEdit, latency, busy }) => (
-    <AccordionItem value={item.id}>
-        <AccordionTrigger className="p-3.5 hover:!bg-ui-surface-muted data-[state=open]:bg-ui-surface-muted data-[state=open]:text-sidebar-color">
-            <div className="grid min-w-0 flex-1 gap-x-5 gap-y-3 lg:grid-cols-[minmax(240px,0.8fr)_minmax(220px,1fr)_auto] lg:items-center">
-                <div className="flex min-w-0 items-center">
-                    <div className="mr-3 flex h-8 w-8 shrink-0 items-center justify-center rounded-ui-sm bg-ui-primary-soft text-ui-primary">
-                        <Network size={18} />
+}> = ({ item, onUse, onLatency, onEdit, latency, busy }) => {
+    const chain = chainLabel(item);
+    const hasLatency = Boolean(busy?.tcp || busy?.udp || !isEmptyLatency(latency?.tcp) || !isEmptyLatency(latency?.udp));
+    const hasIp = Boolean(busy?.ip || latency?.ip);
+    const hasStun = Boolean(busy?.stun || busy?.stun_tcp || latency?.stun || latency?.stun_tcp);
+    const hasAnyResult = hasLatency || hasIp || hasStun;
+
+    return (
+        <AccordionItem
+            value={item.id}
+            className="!mt-0 !rounded-none !border-0 !border-b !border-ui-border/80 !bg-transparent last:!border-b-0 hover:!z-0 hover:!border-ui-border/80 focus-within:!z-0 focus-within:!border-ui-border/80"
+        >
+            <AccordionTrigger className="gap-3 px-4 py-3 text-ui-fg hover:!bg-ui-list-hover/80 hover:!text-ui-fg data-[state=open]:!bg-ui-surface-muted/40 data-[state=open]:!text-ui-fg data-[state=open]:!border-ui-border/50">
+                <div className="flex min-w-0 flex-1 items-center gap-3">
+                    <span
+                        className={clsx(
+                            "mt-0.5 h-2 w-2 shrink-0 rounded-full",
+                            item.enabled ? "bg-ui-success shadow-[0_0_0_3px_color-mix(in_srgb,var(--color-success)_18%,transparent)]" : "bg-ui-muted/50"
+                        )}
+                        title={item.enabled ? "Enabled" : "Disabled"}
+                    />
+
+                    <div className="min-w-0 flex-1">
+                        <div className="flex min-w-0 items-center gap-2">
+                            <span className="truncate text-[0.95rem] font-semibold text-ui-heading">
+                                {item.name || item.id}
+                            </span>
+                            {item.origin && (
+                                <span className="hidden shrink-0 text-[11px] text-ui-muted sm:inline">
+                                    · {item.origin}
+                                </span>
+                            )}
+                            {!item.enabled && (
+                                <Badge variant="secondary" pill className="shrink-0 px-1.5 py-0 text-[0.62rem]">
+                                    Off
+                                </Badge>
+                            )}
+                        </div>
+                        <div className="mt-0.5 truncate text-xs text-ui-muted">
+                            {chain || "No chain"}
+                        </div>
                     </div>
-                    <div className="flex min-w-0 flex-col">
-                        <span className="truncate font-medium text-ui-heading">{item.name || item.id}</span>
-                        <span className="flex min-w-0 items-center gap-2 text-xs text-ui-muted/70">
-                            <span className="truncate font-mono">{item.id}</span>
-                            <span className="shrink-0">{item.origin}</span>
+
+                    <div className="flex shrink-0 items-center gap-1.5">
+                        {collapsedLatencyTypes.map((type) => (
+                            <NodeLatencyBadge
+                                key={type}
+                                type={type}
+                                value={latency?.[type]}
+                                loading={busy?.[type]}
+                            />
+                        ))}
+                    </div>
+                </div>
+            </AccordionTrigger>
+
+            <AccordionContent className="!bg-ui-surface">
+                <div className="space-y-3.5 px-1 pb-1">
+                    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-ui-muted">
+                        <span className="font-mono" title={item.id}>{item.id}</span>
+                        {item.group && (
+                            <span>
+                                <span className="text-ui-muted/70">group</span>{" "}
+                                <span className="text-ui-fg">{item.group}</span>
+                            </span>
+                        )}
+                        <span>
+                            <span className="text-ui-muted/70">status</span>{" "}
+                            <span className={item.enabled ? "text-ui-success" : "text-ui-muted"}>
+                                {item.enabled ? "enabled" : "disabled"}
+                            </span>
                         </span>
                     </div>
-                </div>
-                <div className="flex min-w-0 items-center gap-2 text-sm">
-                    <span className="shrink-0 text-xs text-ui-muted/70">Chain</span>
-                    <span className="truncate font-mono text-ui-fg" title={chainLabel(item)}>{chainLabel(item)}</span>
-                </div>
-                <div className="flex shrink-0 items-center gap-1.5 lg:justify-end">
-                    {collapsedLatencyTypes.map(type => (
-                        <NodeLatencyBadge key={type} type={type} value={latency?.[type]} />
-                    ))}
-                </div>
-            </div>
-        </AccordionTrigger>
-        <AccordionContent>
-            <div className="grid gap-5 lg:grid-cols-[minmax(220px,0.65fr)_minmax(0,1.35fr)]">
-                <div className="grid content-start grid-cols-2 gap-x-4 gap-y-3 text-sm">
-                    <div>
-                        <div className="text-xs text-ui-muted/70">Group</div>
-                        <div className="mt-1 truncate font-medium text-ui-fg">{item.group || "-"}</div>
+
+                    {hasAnyResult ? (
+                        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                            {hasLatency && (
+                                <ResultGroup title="Latency">
+                                    <div className="flex flex-wrap gap-2">
+                                        <ResultChip label="TCP" value={latency?.tcp} loading={busy?.tcp} />
+                                        <ResultChip label="UDP" value={latency?.udp} loading={busy?.udp} />
+                                    </div>
+                                </ResultGroup>
+                            )}
+
+                            {hasIp && (
+                                <ResultGroup title="IP">
+                                    <ResultRow label="IPv4" value={latencyDetail(latency?.ip, "ipv4")} loading={busy?.ip} />
+                                    <ResultRow label="IPv6" value={latencyDetail(latency?.ip, "ipv6")} loading={busy?.ip} />
+                                </ResultGroup>
+                            )}
+
+                            {hasStun && (
+                                <ResultGroup title="STUN">
+                                    <div className="flex flex-wrap gap-2">
+                                        <ResultChip label="NAT" value={latencyDetail(latency?.stun, "mapping")} loading={busy?.stun} />
+                                        <ResultChip label="Filter" value={latencyDetail(latency?.stun, "filtering")} loading={busy?.stun} />
+                                    </div>
+                                    <ResultRow label="Mapped" value={latencyDetail(latency?.stun, "mappedAddress")} loading={busy?.stun} />
+                                    <ResultRow label="TCP" value={latencyDetail(latency?.stun_tcp, "mappedAddress")} loading={busy?.stun_tcp} />
+                                </ResultGroup>
+                            )}
+                        </div>
+                    ) : (
+                        <div className="text-xs text-ui-muted">No test results yet.</div>
+                    )}
+
+                    <div className="flex flex-wrap items-center justify-end gap-2 border-t border-ui-border/70 pt-3">
+                        <Dropdown>
+                            <DropdownTrigger asChild>
+                                <Button size="sm" variant="outline-secondary" onClick={(e) => e.stopPropagation()}>
+                                    <Gauge size={15} className="mr-1.5" />
+                                    Test
+                                    <ChevronDown size={14} className="ml-1" />
+                                </Button>
+                            </DropdownTrigger>
+                            <DropdownContent align="end" className="min-w-[180px] max-w-[220px]">
+                                {latencyActions.map((action) => (
+                                    <DropdownItem key={action.type} disabled={busy?.[action.type]} onSelect={() => onLatency(action.type)}>
+                                        {busy?.[action.type] ? <Spinner size="sm" className="mr-2" /> : <Gauge size={16} className="mr-2" />}
+                                        {action.label}
+                                    </DropdownItem>
+                                ))}
+                            </DropdownContent>
+                        </Dropdown>
+                        <Button size="sm" variant="primary" onClick={(e) => { e.stopPropagation(); onUse(); }}>
+                            <Power size={15} className="mr-1.5" />
+                            Use
+                        </Button>
+                        <Button size="sm" variant="outline-secondary" onClick={(e) => { e.stopPropagation(); onEdit(); }}>
+                            Edit
+                        </Button>
                     </div>
-                    <div>
-                        <div className="text-xs text-ui-muted/70">Status</div>
-                        <div className="mt-1 font-medium text-ui-fg">{item.enabled ? "Enabled" : "Disabled"}</div>
-                    </div>
-                    <div className="col-span-2 min-w-0">
-                        <div className="text-xs text-ui-muted/70">Node ID</div>
-                        <div className="mt-1 truncate font-mono text-xs text-ui-fg" title={item.id}>{item.id}</div>
-                    </div>
                 </div>
-                <div className="border-t border-ui-border pt-4 lg:border-l lg:border-t-0 lg:pl-5 lg:pt-0">
-                    <div className="mb-3 text-sm font-medium text-ui-fg">Test results</div>
-                    <div className="grid grid-cols-[repeat(auto-fit,minmax(130px,1fr))] gap-2">
-                        <LatencyInfo label="TCP Latency" value={latency?.tcp} loading={busy?.tcp} />
-                        <LatencyInfo label="UDP Latency" value={latency?.udp} loading={busy?.udp} />
-                        {(latency?.ip || busy?.ip) && (
-                            <>
-                                <LatencyInfo label="IPv4" value={latencyDetail(latency?.ip, "ipv4")} loading={busy?.ip} />
-                                <LatencyInfo label="IPv6" value={latencyDetail(latency?.ip, "ipv6")} loading={busy?.ip} />
-                            </>
-                        )}
-                        {(latency?.stun || busy?.stun) && (
-                            <>
-                                <LatencyInfo label="NAT Type" value={latencyDetail(latency?.stun, "mapping")} loading={busy?.stun} />
-                                <LatencyInfo label="Filtering" value={latencyDetail(latency?.stun, "filtering")} loading={busy?.stun} />
-                                <LatencyInfo label="Mapped Address" value={latencyDetail(latency?.stun, "mappedAddress")} loading={busy?.stun} />
-                            </>
-                        )}
-                        {(latency?.stun_tcp || busy?.stun_tcp) && (
-                            <LatencyInfo label="STUN TCP IP" value={latencyDetail(latency?.stun_tcp, "mappedAddress")} loading={busy?.stun_tcp} />
-                        )}
-                    </div>
-                </div>
-                <div className="flex flex-wrap justify-end gap-2 border-t border-ui-border pt-4 lg:col-span-2">
-                    <Dropdown>
-                        <DropdownTrigger asChild>
-                            <Button size="sm" variant="outline-secondary">
-                                <Gauge size={16} className="mr-2" />
-                                Test
-                                <ChevronDown size={14} className="ml-1" />
-                            </Button>
-                        </DropdownTrigger>
-                        <DropdownContent align="end" className="min-w-[180px] max-w-[220px]">
-                            {latencyActions.map(action => (
-                                <DropdownItem key={action.type} disabled={busy?.[action.type]} onSelect={() => onLatency(action.type)}>
-                                    {busy?.[action.type] ? <Spinner size="sm" className="mr-2" /> : <Gauge size={16} className="mr-2" />}
-                                    {action.label}
-                                </DropdownItem>
-                            ))}
-                        </DropdownContent>
-                    </Dropdown>
-                    <Button size="sm" variant="outline-primary" onClick={onUse}>
-                        <Power size={16} className="mr-2" />
-                        Use
-                    </Button>
-                    <Button size="sm" onClick={onEdit}>
-                        Edit
-                    </Button>
-                </div>
-            </div>
-        </AccordionContent>
-    </AccordionItem>
-);
+            </AccordionContent>
+        </AccordionItem>
+    );
+};
 
 const NodeImportModal: FC<{
     show: boolean;
@@ -361,6 +561,7 @@ export default function Group() {
     const [showdata, setShowdata] = useState({ show: false, id: "", new: false });
     const [importOpen, setImportOpen] = useState(false);
     const [selectedGroup, setSelectedGroup] = useState("");
+    const [query, setQuery] = useState("");
     const [latency, setLatency] = useLocalStorage<Record<string, NodeLatencyState>>("latency-v2-contract", {});
     const [busyLatency, setBusyLatency] = useState<Record<string, Partial<Record<NodeLatencyType, boolean>>>>({});
     const [latencyHTTP] = useLocalStorage(LatencyHTTPUrlKey, LatencyHTTPUrlDefault);
@@ -377,10 +578,30 @@ export default function Group() {
         const values = new Set(items.map(item => item.group || "manual"));
         return Array.from(values).sort((a, b) => a.localeCompare(b));
     }, [items]);
-    const groupItems = useMemo(
-        () => selectedGroup ? items.filter(item => (item.group || "manual") === selectedGroup) : [],
-        [items, selectedGroup],
-    );
+    const groupCounts = useMemo(() => {
+        const counts = new Map<string, number>();
+        for (const item of items) {
+            const group = item.group || "manual";
+            counts.set(group, (counts.get(group) ?? 0) + 1);
+        }
+        return counts;
+    }, [items]);
+    const groupItems = useMemo(() => {
+        if (!selectedGroup) return [];
+        const inGroup = items.filter(item => (item.group || "manual") === selectedGroup);
+        const q = query.trim().toLowerCase();
+        if (!q) return inGroup;
+        return inGroup.filter((item) => {
+            const haystack = [
+                item.name,
+                item.id,
+                item.origin,
+                chainLabel(item),
+                ...item.chain.map((step) => step.type),
+            ].join(" ").toLowerCase();
+            return haystack.includes(q);
+        });
+    }, [items, query, selectedGroup]);
     const modalGroups = useMemo(
         () => selectedGroup
             ? [selectedGroup, ...groups.filter(group => group !== selectedGroup)]
@@ -390,6 +611,10 @@ export default function Group() {
 
     useEffect(() => {
         if (selectedGroup && !groups.includes(selectedGroup)) setSelectedGroup("");
+    }, [groups, selectedGroup]);
+
+    useEffect(() => {
+        if (!selectedGroup && groups.length > 0) setSelectedGroup(groups[0]);
     }, [groups, selectedGroup]);
 
     if (apiError) return <ErrorDisplay statusCode={apiError.code} title={apiError.msg} raw={errorRaw(apiError.raw)} />;
@@ -468,73 +693,100 @@ export default function Group() {
                 }}
             />
 
-            <div className="mb-4 flex flex-wrap items-center justify-end gap-3">
-                <Dropdown>
-                    <DropdownTrigger asChild>
-                        <Button variant="outline-secondary" className="min-w-[128px] justify-between">
-                            {selectedGroup || "Group"}
-                            <ChevronDown size={16} className="ml-2" />
-                        </Button>
-                    </DropdownTrigger>
-                    <DropdownContent align="end" className="min-w-[180px] max-w-[260px]">
-                        {groups.length === 0 ? (
-                            <DropdownItem disabled>No groups</DropdownItem>
-                        ) : groups.map(group => {
-                            const count = items.filter(item => (item.group || "manual") === group).length;
-                            return (
-                                <DropdownItem key={group} onSelect={() => setSelectedGroup(group)} className="justify-between gap-3">
-                                    <span className="truncate">{group}</span>
-                                    <span className="text-xs text-ui-muted">{count}</span>
-                                </DropdownItem>
-                            );
-                        })}
-                    </DropdownContent>
-                </Dropdown>
-                <Button onClick={handleCreate}>
-                    <Plus className="mr-1" size={16} /> New
-                </Button>
-                <Button variant="outline-secondary" onClick={() => setImportOpen(true)}>
-                    <Upload className="mr-1" size={16} /> Import
-                </Button>
-            </div>
+            <Card className="mb-4 overflow-hidden">
+                <CardHeader className="gap-4 px-4 py-4">
+                    <div className="flex min-w-0 flex-1 flex-wrap items-start justify-between gap-3">
+                        <IconBox
+                            icon={Layers}
+                            tone="primary"
+                            title="Outbound"
+                            description={`${items.length} nodes across ${groups.length} ${groups.length === 1 ? "group" : "groups"}`}
+                        />
+                        <div className="flex flex-wrap items-center gap-2">
+                            <Button onClick={handleCreate}>
+                                <Plus className="mr-1" size={16} /> New
+                            </Button>
+                            <Button variant="outline-secondary" onClick={() => setImportOpen(true)}>
+                                <Upload className="mr-1" size={16} /> Import
+                            </Button>
+                        </div>
+                    </div>
+                </CardHeader>
 
-            {!selectedGroup ? (
-                <Card className="mb-4">
-                    <CardBody>
-                        <div className="py-4 text-center font-semibold text-ui-muted">
-                            Please select a group to display nodes.
+                <CardBody className="space-y-4 pt-4" density="compact">
+                    {groups.length === 0 ? (
+                        <div className="rounded-ui-lg border border-dashed border-ui-border px-4 py-10 text-center">
+                            <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-ui-primary-soft text-ui-primary">
+                                <Network size={22} />
+                            </div>
+                            <div className="text-sm font-semibold text-ui-heading">No outbound groups yet</div>
+                            <div className="mt-1 text-xs text-ui-muted">Create a node or import JSON to get started.</div>
+                            <div className="mt-4 flex justify-center gap-2">
+                                <Button size="sm" onClick={handleCreate}>
+                                    <Plus size={14} className="mr-1" /> New node
+                                </Button>
+                                <Button size="sm" variant="outline-secondary" onClick={() => setImportOpen(true)}>
+                                    <Upload size={14} className="mr-1" /> Import
+                                </Button>
+                            </div>
                         </div>
-                    </CardBody>
-                </Card>
-            ) : (
-                <Card className="mb-4">
-                    <CardHeader className="px-4 py-3">
-                        <div className="min-w-0">
-                            <div className="truncate font-medium text-ui-heading">{selectedGroup}</div>
-                            <div className="mt-0.5 text-xs text-ui-muted">{groupItems.length} {groupItems.length === 1 ? "node" : "nodes"}</div>
-                        </div>
-                    </CardHeader>
-                    <CardBody className="p-0" density="compact">
-                        {groupItems.length === 0 ? (
-                            <div className="m-4 rounded-ui-lg border border-dashed border-ui-border p-6 text-center text-ui-muted">No nodes in this group.</div>
-                        ) : (
-                            <Accordion type="single" collapsible className="mb-0 rounded-none shadow-none transition-none hover:translate-y-0 hover:border-transparent hover:shadow-none">
-                                {groupItems.map(item => (
-                                    <NodeItem
-                                        key={item.id}
-                                        item={item}
-                                        latency={latency[item.id]}
-                                        busy={busyLatency[item.id]}
-                                        onUse={() => handleUse(item.id)}
-                                        onLatency={(type) => handleLatency(item.id, type)}
-                                        onEdit={() => setShowdata({ show: true, id: item.id, new: false })}
+                    ) : (
+                        <>
+                            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                <GroupPicker
+                                    groups={groups}
+                                    counts={groupCounts}
+                                    value={selectedGroup}
+                                    onChange={setSelectedGroup}
+                                />
+                                <div className="relative w-full shrink-0 sm:w-[240px] lg:w-[280px]">
+                                    <Search size={14} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-ui-muted" />
+                                    <Input
+                                        value={query}
+                                        onChange={(e) => setQuery(e.target.value)}
+                                        placeholder="Search nodes..."
+                                        className="h-9 pl-9 text-sm"
                                     />
-                                ))}
-                            </Accordion>
-                        )}
-                    </CardBody>
-                </Card>
-            )}
+                                </div>
+                            </div>
+
+                            <div className="overflow-hidden rounded-ui-xl border border-ui-border bg-ui-surface">
+                                {groupItems.length === 0 ? (
+                                    <div className="px-4 py-12 text-center">
+                                        <Search className="mx-auto mb-2 text-ui-muted" size={28} />
+                                        <div className="text-sm font-medium text-ui-heading">
+                                            {query.trim() ? "No matching nodes" : "No nodes in this group"}
+                                        </div>
+                                        <div className="mt-1 text-xs text-ui-muted">
+                                            {query.trim()
+                                                ? "Try another keyword, or clear the search."
+                                                : "Add a node to this group to see it here."}
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <Accordion
+                                        type="single"
+                                        collapsible
+                                        className="!mb-0 !rounded-none !border-0 !shadow-none !transition-none hover:!translate-y-0 hover:!border-transparent hover:!shadow-none"
+                                    >
+                                        {groupItems.map((item) => (
+                                            <NodeItem
+                                                key={item.id}
+                                                item={item}
+                                                latency={latency[item.id]}
+                                                busy={busyLatency[item.id]}
+                                                onUse={() => handleUse(item.id)}
+                                                onLatency={(type) => handleLatency(item.id, type)}
+                                                onEdit={() => setShowdata({ show: true, id: item.id, new: false })}
+                                            />
+                                        ))}
+                                    </Accordion>
+                                )}
+                            </div>
+                        </>
+                    )}
+                </CardBody>
+            </Card>
         </MainContainer>
     );
 }

--- a/src/docs/group/publish/page.tsx
+++ b/src/docs/group/publish/page.tsx
@@ -188,7 +188,7 @@ function PublishPage() {
                     <div className="flex w-full flex-col items-stretch gap-3 sm:flex-row sm:items-center sm:justify-between">
                         <div className="flex min-w-0 flex-col overflow-hidden">
                             <span className="font-bold">{pub.name}</span>
-                            <small className="text-gray-500 truncate">{pub.address}/{pub.path} • {pub.points.length} nodes</small>
+                            <small className="text-ui-muted truncate">{pub.address}/{pub.path} • {pub.points.length} nodes</small>
                         </div>
                         <Button className="self-end sm:self-auto" variant="outline-danger" size="sm" onClick={(e) => { e.stopPropagation(); setConfirmDelete({ show: true, name: pub.name }); }}>
                             <Trash size={16} />
@@ -198,10 +198,10 @@ function PublishPage() {
                 header={
                     <>
                         <div className="flex items-center">
-                            <IconBox icon={Share2} color="#8b5cf6" />
+                            <IconBox icon={Share2} tone="violet" />
                             <div>
                                 <h5 className="mb-0 font-bold">Publish</h5>
-                                <small className="text-gray-500">Share selected nodes as publish configs</small>
+                                <small className="text-ui-muted">Share selected nodes as publish configs</small>
                             </div>
                         </div>
                         <Button onClick={() => setEditing({ show: true, isEdit: false, value: defaultPublish() })}>

--- a/src/docs/group/subscribe/page.tsx
+++ b/src/docs/group/subscribe/page.tsx
@@ -23,13 +23,13 @@ const LinkItem: FC<{ linkData: Link; isUpdating: boolean; onUpdate: () => void; 
     return (
         <div className="grid flex-1 gap-3 overflow-hidden sm:grid-cols-[1fr_auto] sm:items-center">
             <div className="flex items-center gap-3 min-w-0 overflow-hidden">
-                <IconBoxRounded icon={Rss} color="#0d6efd" style={{ width: 40, height: 40, flexShrink: 0 }} />
+                <IconBoxRounded icon={Rss} tone="primary" style={{ width: 40, height: 40, flexShrink: 0 }} />
                 <div className="min-w-0 overflow-hidden">
                     <div className="flex min-w-0 items-center gap-2">
                         <div className="font-bold truncate">{linkData.name}</div>
                         <Badge variant="secondary" pill className="uppercase">{linkData.type || "reserve"}</Badge>
                     </div>
-                    <small className="text-gray-500 truncate block">{linkData.url}</small>
+                    <small className="text-ui-muted truncate block">{linkData.url}</small>
                 </div>
             </div>
             <div className="flex gap-2 justify-end">
@@ -138,10 +138,10 @@ function Subscribe() {
                 header={
                     <>
                         <div className="flex items-center">
-                            <IconBox icon={CloudDownload} color="#0ea5e9" />
+                            <IconBox icon={CloudDownload} tone="primary" />
                             <div>
                                 <h5 className="mb-0 font-bold">Subscriptions</h5>
-                                <small className="text-gray-500">Manage remote configuration links</small>
+                                <small className="text-ui-muted">Manage remote configuration links</small>
                             </div>
                         </div>
                         <Button onClick={() => setShowAddModal(true)}><Plus className="me-1" size={16} /> Add</Button>

--- a/src/docs/home/TrafficChartv2.tsx
+++ b/src/docs/home/TrafficChartv2.tsx
@@ -1,11 +1,26 @@
-import { FC, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { FC, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import uPlot from 'uplot';
 import 'uplot/dist/uPlot.min.css';
 import { formatBytes } from './format';
-import { Tooltip } from './tooltip';
+import { Tooltip, type ChartTooltipHandle } from './tooltip';
 
 const BUFFER_GROWTH_SIZE = 1024;
+
+function chartPalette() {
+    const dark = typeof document !== 'undefined'
+        && document.documentElement.getAttribute('data-bs-theme') === 'dark';
+    return {
+        uploadStroke: dark ? '#8fc7a8' : '#198754',
+        uploadFill: dark ? 'rgba(143, 199, 168, 0.12)' : 'rgba(25, 135, 84, 0.12)',
+        downloadStroke: dark ? '#7dd3fc' : '#0284c7',
+        downloadFill: dark ? 'rgba(125, 211, 252, 0.12)' : 'rgba(2, 132, 199, 0.12)',
+        axis: dark ? '#94a3b8' : '#64748b',
+        grid: dark ? 'rgba(255, 255, 255, 0.06)' : 'rgba(15, 23, 42, 0.06)',
+        pointFill: dark ? '#1e293b' : '#ffffff',
+    };
+}
+
 const TOOLTIP_WIDTH = 176;
 const TOOLTIP_HEIGHT = 72;
 const TOOLTIP_GAP = 12;
@@ -160,14 +175,7 @@ const TrafficChart: FC<TrafficChartProps> = ({ data, minHeight }) => {
     const wrapperRef = useRef<HTMLDivElement>(null);
     const chartRef = useRef<HTMLDivElement>(null);
     const uPlotInst = useRef<uPlot | null>(null);
-    const [tooltip, setTooltip] = useState({
-        visible: false,
-        left: 0,
-        top: 0,
-        label: '',
-        upload: 0,
-        download: 0,
-    });
+    const tooltipRef = useRef<ChartTooltipHandle | null>(null);
     const indices = useMemo(() => Array.from({ length: data.labels.length }, (_, i) => i), [data.labels.length]);
     const bufferStateRef = useRef<{
         bufSize: number;
@@ -215,6 +223,7 @@ const TrafficChart: FC<TrafficChartProps> = ({ data, minHeight }) => {
         if (width === 0) width = 600;
         if (height === 0) height = 300;
 
+        const palette = chartPalette();
         const opts: uPlot.Options = {
             width: width,
             height: height,
@@ -229,8 +238,8 @@ const TrafficChart: FC<TrafficChartProps> = ({ data, minHeight }) => {
                 { value: (_, rawValue) => data.labels[rawValue] || "" },
                 {
                     label: t('upload'),
-                    stroke: "#10b981",
-                    fill: "rgba(16, 185, 129, 0.1)",
+                    stroke: palette.uploadStroke,
+                    fill: palette.uploadFill,
                     width: 2,
                     points: { show: false },
                     value: (_, rawValue) => formatBytes(rawValue ?? 0, 2, " ") + '/S',
@@ -238,8 +247,8 @@ const TrafficChart: FC<TrafficChartProps> = ({ data, minHeight }) => {
                 },
                 {
                     label: t('download'),
-                    stroke: "#3b82f6",
-                    fill: "rgba(59, 130, 246, 0.1)",
+                    stroke: palette.downloadStroke,
+                    fill: palette.downloadFill,
                     width: 2,
                     points: { show: false },
                     value: (_, rawValue) => formatBytes(rawValue ?? 0, 2, " ") + '/S',
@@ -250,10 +259,10 @@ const TrafficChart: FC<TrafficChartProps> = ({ data, minHeight }) => {
                 { show: false },
                 {
                     show: true,
-                    stroke: "#475569",
+                    stroke: palette.axis,
                     font: '10px sans-serif',
-                    grid: { show: true, stroke: "rgba(255, 255, 255, 0.05)", width: 1 },
-                    ticks: { show: true, stroke: "rgba(255, 255, 255, 0.05)" },
+                    grid: { show: true, stroke: palette.grid, width: 1 },
+                    ticks: { show: true, stroke: palette.grid },
                     values: (_, ticks) => ticks.map(v => formatBytes(Number(v), 0, " ") + '/S'),
                     size: 65,
                     gap: 0,
@@ -265,7 +274,7 @@ const TrafficChart: FC<TrafficChartProps> = ({ data, minHeight }) => {
                 points: {
                     size: 9, width: 2,
                     stroke: (u, seriesIdx) => u.series[seriesIdx].stroke as string,
-                    fill: () => "#1e293b",
+                    fill: () => palette.pointFill,
                 }
             },
             scales: {
@@ -278,7 +287,7 @@ const TrafficChart: FC<TrafficChartProps> = ({ data, minHeight }) => {
                         const { idx, left: cursorLeft = 0, top: cursorTop = 0 } = u.cursor;
 
                         if (idx == null) {
-                            setTooltip((t) => ({ ...t, visible: false }));
+                            tooltipRef.current?.hide();
                             return;
                         }
 
@@ -309,8 +318,7 @@ const TrafficChart: FC<TrafficChartProps> = ({ data, minHeight }) => {
                         left = Math.min(Math.max(left, TOOLTIP_GAP), maxLeft);
                         top = Math.min(Math.max(top, TOOLTIP_GAP), maxTop);
 
-                        setTooltip({
-                            visible: true,
+                        tooltipRef.current?.show({
                             left,
                             top,
                             label,
@@ -377,7 +385,7 @@ const TrafficChart: FC<TrafficChartProps> = ({ data, minHeight }) => {
                 ref={chartRef}
                 className="absolute top-0 left-0 w-full h-full overflow-hidden"
             />
-            <Tooltip {...tooltip} />
+            <Tooltip ref={tooltipRef} />
         </div>
     );
 };

--- a/src/docs/home/page.tsx
+++ b/src/docs/home/page.tsx
@@ -80,6 +80,7 @@ function HomePage() {
     const [nodeModal, setNodeModal] = useState<{ show: boolean; node?: Node }>({ show: false });
     const { data: now, error: nowError } = useSWR("/api/v2/nodes/selected", selectedNodes, {
         refreshInterval: 5000,
+        revalidateOnFocus: false,
     });
     const [traffic, setTraffic] = useState<{ labels: string[], upload: number[], download: number[], rawMax: number }>
         ({ labels: [], upload: [], download: [], rawMax: 0 });
@@ -131,7 +132,7 @@ function HomePage() {
             />
 
             <div className="mb-3 shrink-0">
-                <FlowContainer onFlow={appendTraffic} />
+                <FlowContainer onFlow={isLiveTraffic ? appendTraffic : undefined} />
             </div>
 
             <div className="mb-4 grid shrink-0 gap-3 sm:grid-cols-2">
@@ -192,11 +193,11 @@ function HomePage() {
                             </div>
                             <div className="flex items-center justify-end gap-3 text-[11px] text-ui-muted">
                                 <span className="inline-flex items-center gap-1.5">
-                                    <ArrowDownToLine size={12} className="text-sky-500" />
+                                    <ArrowDownToLine size={12} className="text-ui-info" />
                                     Download
                                 </span>
                                 <span className="inline-flex items-center gap-1.5">
-                                    <ArrowUpFromLine size={12} className="text-emerald-500" />
+                                    <ArrowUpFromLine size={12} className="text-ui-success" />
                                     Upload
                                 </span>
                             </div>

--- a/src/docs/home/page.tsx
+++ b/src/docs/home/page.tsx
@@ -3,18 +3,20 @@
 import { getTelemetry, getTraffic } from "@/api/connections";
 import { selectedNodes } from "@/api/nodes";
 import { Button } from "@/component/v2/button";
-import { Card, CardBody, CardHeader, MainContainer } from "@/component/v2/card";
+import { Card, CardBody, CardHeader, IconBox, MainContainer } from "@/component/v2/card";
 import Loading from "@/component/v2/loading";
 import type { TrafficSeries } from "@/contract/connection";
 import type { Node } from "@/contract/node";
+import clsx from "clsx";
+import { Activity, ArrowDownToLine, ArrowUpFromLine, Network } from "lucide-react";
+import { FC, useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import useSWR from "swr";
 import dynamic from "../../component/AsyncComponent";
 import { Flow, FlowContainer } from "../connections/components";
 import Activates from "../group/activates/page";
 import { NodeModal } from "../node/modal";
 import TelemetryOverview from "./TelemetryOverview";
-import { useCallback, useMemo, useState } from "react";
-import { useTranslation } from "react-i18next";
-import useSWR from "swr";
 
 const trafficRanges: Array<{ key: string; label: string; interval?: TrafficSeries["interval"]; durationMs?: number }> = [
     { key: "live", label: "Live" },
@@ -24,6 +26,54 @@ const trafficRanges: Array<{ key: string; label: string; interval?: TrafficSerie
     { key: "12m", label: "12M", interval: "month", durationMs: 365 * 24 * 60 * 60 * 1000 },
 ];
 const MAX_POINTS = 120;
+
+const EndpointCard: FC<{
+    label: string;
+    node?: Node;
+    error?: string;
+    onOpen: (node: Node) => void;
+}> = ({ label, node, error, onOpen }) => {
+    const { t } = useTranslation(["common"]);
+    const unavailable = t("state.notAvailable");
+
+    return (
+        <button
+            type="button"
+            disabled={!node || Boolean(error)}
+            onClick={() => node && onOpen(node)}
+            className={clsx(
+                "group flex min-h-[92px] w-full min-w-0 flex-col justify-center rounded-ui-xl border border-ui-border bg-ui-surface p-4 text-left shadow-ui-card transition-colors",
+                node && !error
+                    ? "cursor-pointer hover:border-ui-primary/35 hover:bg-ui-surface-muted/40"
+                    : "cursor-default opacity-90"
+            )}
+        >
+            <div className="mb-2 flex items-center justify-between gap-2">
+                <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-ui-muted">{label}</span>
+                <Network size={14} className="shrink-0 text-ui-muted/70 transition-colors group-hover:text-ui-primary" />
+            </div>
+            {error ? (
+                <div className="truncate text-sm font-medium text-ui-danger" title={error}>{error}</div>
+            ) : node ? (
+                <div className="min-w-0 space-y-1">
+                    <div className="truncate text-sm font-semibold text-ui-heading" title={node.name || node.id}>
+                        {node.name || node.id}
+                    </div>
+                    <div className="flex min-w-0 items-center gap-2">
+                        {node.group && (
+                            <span className="shrink-0 rounded-full bg-ui-chip px-2 py-0.5 text-[11px] font-medium text-ui-chip-fg">
+                                {node.group}
+                            </span>
+                        )}
+                        <span className="truncate font-mono text-[11px] text-ui-muted" title={node.id}>{node.id}</span>
+                    </div>
+                </div>
+            ) : (
+                <div className="text-sm font-medium text-ui-muted">{unavailable}</div>
+            )}
+        </button>
+    );
+};
 
 function HomePage() {
     const { t } = useTranslation(["home", "common"]);
@@ -71,88 +121,112 @@ function HomePage() {
         });
     }, []);
 
-    const endpointValue = (node: Node | undefined) => {
-        if (nowError) return nowError.msg;
-        if (!node) return t("common:state.notAvailable");
-        return (
-            <a
-                href="#"
-                className="text-blue-500 hover:underline"
-                onClick={(event) => {
-                    event.preventDefault();
-                    setNodeModal({ show: true, node });
-                }}
-            >
-                {node.group}/{node.name}
-            </a>
-        );
-    };
-
-    return <div className="h-full flex flex-col box-border">
-        <NodeModal
-            show={nodeModal.show}
-            node={nodeModal.node}
-            readOnly
-            onHide={() => setNodeModal({ show: false })}
-        />
-
-        <div className="shrink-0 mb-4">
-            <FlowContainer
-                onFlow={appendTraffic}
-                extra_fields={[
-                    {
-                        label: t("tcpEndpoint"),
-                        value: endpointValue(now?.tcp),
-                        error: nowError?.msg,
-                    },
-                    {
-                        label: t("udpEndpoint"),
-                        value: endpointValue(now?.udp),
-                        error: nowError?.msg,
-                    },
-                ]}
+    return (
+        <div className="box-border flex h-full flex-col">
+            <NodeModal
+                show={nodeModal.show}
+                node={nodeModal.node}
+                readOnly
+                onHide={() => setNodeModal({ show: false })}
             />
-        </div>
 
-        <MainContainer>
-            <Card className="min-h-[400px]">
-                <CardHeader className="flex-wrap gap-3">
-                    <div>
-                        <div className="font-medium text-ui-heading">{isLiveTraffic ? "Live traffic" : "Traffic history"}</div>
-                        <div className="mt-0.5 text-xs text-ui-muted">
-                            {isLiveTraffic ? "Current download and upload speed" : "Download and upload totals by period"}
+            <div className="mb-3 shrink-0">
+                <FlowContainer onFlow={appendTraffic} />
+            </div>
+
+            <div className="mb-4 grid shrink-0 gap-3 sm:grid-cols-2">
+                <EndpointCard
+                    label={t("tcpEndpoint")}
+                    node={now?.tcp}
+                    error={nowError?.msg}
+                    onOpen={(node) => setNodeModal({ show: true, node })}
+                />
+                <EndpointCard
+                    label={t("udpEndpoint")}
+                    node={now?.udp}
+                    error={nowError?.msg}
+                    onOpen={(node) => setNodeModal({ show: true, node })}
+                />
+            </div>
+
+            <MainContainer>
+                <Card className="min-h-[400px]" density="compact">
+                    <CardHeader className="gap-3 px-4 py-3.5">
+                        <div className="flex min-w-0 flex-1 items-start gap-3">
+                            <IconBox
+                                icon={Activity}
+                                tone="primary"
+                                title={isLiveTraffic ? "Live traffic" : "Traffic history"}
+                                description={isLiveTraffic ? "Current download and upload speed" : "Download and upload totals by period"}
+                            />
                         </div>
-                    </div>
-                    <div className="flex flex-wrap gap-1" aria-label="Traffic range">
-                        {trafficRanges.map(item => (
-                            <Button key={item.key} size="xs" variant={item.key === range.key ? "primary" : "outline-secondary"} onClick={() => setSelectedRange(item.key)}>
-                                {item.label}
-                            </Button>
-                        ))}
-                    </div>
-                </CardHeader>
-                <CardBody className="!p-0">
-                    {isLiveTraffic
-                        ? <TrafficChartDynamic data={traffic} minHeight={400} />
-                        : <TrafficHistoryChartDynamic data={trafficHistory} error={trafficHistoryError?.msg} minHeight={400} />}
-                </CardBody>
-            </Card>
 
-            <Card>
-                <CardHeader>
-                    <div>
-                        <div className="font-medium text-ui-heading">Traffic breakdown</div>
-                        <div className="mt-0.5 text-xs text-ui-muted">Top traffic and failures for selected time range</div>
-                    </div>
-                </CardHeader>
-                <CardBody>
-                    <TelemetryOverview data={telemetry} error={telemetryError?.msg} />
-                </CardBody>
-            </Card>
-        </MainContainer>
+                        <div className="flex flex-col items-stretch gap-2 sm:items-end">
+                            <div
+                                className="inline-flex flex-wrap items-center rounded-full border border-ui-border bg-ui-surface-muted/50 p-1"
+                                aria-label="Traffic range"
+                            >
+                                {trafficRanges.map(item => {
+                                    const active = item.key === range.key;
+                                    return (
+                                        <Button
+                                            key={item.key}
+                                            size="xs"
+                                            variant={active ? "primary" : "outline-secondary"}
+                                            className={clsx(
+                                                "!rounded-full border-transparent shadow-none",
+                                                !active && "!bg-transparent !text-ui-muted hover:!bg-ui-hover hover:!text-ui-fg"
+                                            )}
+                                            onClick={() => setSelectedRange(item.key)}
+                                        >
+                                            {item.key === "live" && (
+                                                <span className={clsx(
+                                                    "mr-1.5 inline-block h-1.5 w-1.5 rounded-full",
+                                                    active ? "bg-white animate-pulse" : "bg-ui-muted"
+                                                )} />
+                                            )}
+                                            {item.label}
+                                        </Button>
+                                    );
+                                })}
+                            </div>
+                            <div className="flex items-center justify-end gap-3 text-[11px] text-ui-muted">
+                                <span className="inline-flex items-center gap-1.5">
+                                    <ArrowDownToLine size={12} className="text-sky-500" />
+                                    Download
+                                </span>
+                                <span className="inline-flex items-center gap-1.5">
+                                    <ArrowUpFromLine size={12} className="text-emerald-500" />
+                                    Upload
+                                </span>
+                            </div>
+                        </div>
+                    </CardHeader>
+                    <CardBody className="!p-0">
+                        {isLiveTraffic
+                            ? <TrafficChartDynamic data={traffic} minHeight={400} />
+                            : <TrafficHistoryChartDynamic data={trafficHistory} error={trafficHistoryError?.msg} minHeight={400} />}
+                    </CardBody>
+                </Card>
 
-        <Activates showFooter={false} />
-    </div>
+                <Card density="compact">
+                    <CardHeader className="px-4 py-3.5">
+                        <IconBox
+                            icon={Activity}
+                            tone="violet"
+                            title="Traffic breakdown"
+                            description={`Top traffic and failures · ${isLiveTraffic ? "24H" : range.label}`}
+                        />
+                    </CardHeader>
+                    <CardBody className="pt-4" density="compact">
+                        <TelemetryOverview data={telemetry} error={telemetryError?.msg} />
+                    </CardBody>
+                </Card>
+            </MainContainer>
+
+            <Activates showFooter={false} />
+        </div>
+    );
 }
 
 const TrafficHistoryChartDynamic = dynamic(() => import("./TrafficHistoryChart"), { ssr: false, loading: <Loading /> });

--- a/src/docs/home/tooltip.tsx
+++ b/src/docs/home/tooltip.tsx
@@ -1,5 +1,5 @@
-import { formatBytes } from "./format";
 import { createPortal } from "react-dom";
+import { formatBytes } from "./format";
 
 interface TooltipProps {
     label?: string;
@@ -28,7 +28,7 @@ export const Tooltip: React.FC<TooltipProps> = ({ label, upload, download, left,
                 <span className="font-medium">{formatBytes(upload ?? 0, 2, ' ') + '/S'}</span>
             </div>
             <div className="flex items-center gap-2">
-                <div className="w-2 h-2 bg-blue-500 rounded-full" />
+                <div className="w-2 h-2 bg-ui-primary rounded-full" />
                 <span className="text-slate-300">Download:</span>
                 <span className="font-medium">{formatBytes(download ?? 0, 2, ' ') + '/S'}</span>
             </div>

--- a/src/docs/home/tooltip.tsx
+++ b/src/docs/home/tooltip.tsx
@@ -1,38 +1,60 @@
+import { forwardRef, useImperativeHandle, useRef } from "react";
 import { createPortal } from "react-dom";
 import { formatBytes } from "./format";
 
-interface TooltipProps {
-    label?: string;
-    upload?: number;
-    download?: number;
-    left: number;
-    top: number;
-    visible: boolean;
-}
+export type ChartTooltipHandle = {
+    show: (payload: {
+        left: number;
+        top: number;
+        label: string;
+        upload: number;
+        download: number;
+    }) => void;
+    hide: () => void;
+};
 
-export const Tooltip: React.FC<TooltipProps> = ({ label, upload, download, left, top, visible }) => {
+export const Tooltip = forwardRef<ChartTooltipHandle>(function Tooltip(_, ref) {
+    const rootRef = useRef<HTMLDivElement>(null);
+    const labelRef = useRef<HTMLDivElement>(null);
+    const uploadRef = useRef<HTMLSpanElement>(null);
+    const downloadRef = useRef<HTMLSpanElement>(null);
+
+    useImperativeHandle(ref, () => ({
+        show({ left, top, label, upload, download }) {
+            const root = rootRef.current;
+            if (!root) return;
+            root.style.display = "block";
+            root.style.left = `${left}px`;
+            root.style.top = `${top}px`;
+            if (labelRef.current) labelRef.current.textContent = label;
+            if (uploadRef.current) uploadRef.current.textContent = `${formatBytes(upload, 2, " ")}/S`;
+            if (downloadRef.current) downloadRef.current.textContent = `${formatBytes(download, 2, " ")}/S`;
+        },
+        hide() {
+            if (rootRef.current) rootRef.current.style.display = "none";
+        },
+    }), []);
+
     if (typeof document === "undefined") return null;
 
     return createPortal(
         <div
-            className={`fixed pointer-events-none bg-black p-2 rounded text-white text-xs w-[176px] z-[2147483646] shadow-md ${visible ? 'block' : 'hidden'}`}
-            style={{
-                left,
-                top,
-            }}
+            ref={rootRef}
+            className="fixed pointer-events-none hidden rounded bg-ui-heading p-2 text-xs text-ui-bg shadow-md w-[176px] z-[2147483646]"
+            style={{ left: 0, top: 0 }}
         >
-            <div className="font-semibold mb-1 text-slate-100">{label}</div>
-            <div className="flex items-center gap-2 mb-0.5">
-                <div className="w-2 h-2 bg-emerald-500 rounded-full" />
-                <span className="text-slate-300">Upload:</span>
-                <span className="font-medium">{formatBytes(upload ?? 0, 2, ' ') + '/S'}</span>
+            <div ref={labelRef} className="mb-1 font-semibold text-ui-bg/95" />
+            <div className="mb-0.5 flex items-center gap-2">
+                <div className="h-2 w-2 rounded-full bg-ui-success" />
+                <span className="text-ui-bg/70">Upload:</span>
+                <span ref={uploadRef} className="font-medium" />
             </div>
             <div className="flex items-center gap-2">
-                <div className="w-2 h-2 bg-ui-primary rounded-full" />
-                <span className="text-slate-300">Download:</span>
-                <span className="font-medium">{formatBytes(download ?? 0, 2, ' ') + '/S'}</span>
+                <div className="h-2 w-2 rounded-full bg-ui-info" />
+                <span className="text-ui-bg/70">Download:</span>
+                <span ref={downloadRef} className="font-medium" />
             </div>
         </div>,
         document.body
     );
-};
+});

--- a/src/docs/inbound/page.tsx
+++ b/src/docs/inbound/page.tsx
@@ -95,7 +95,7 @@ const InboundEditor: FC<{
                 label="Enabled"
                 checked={inbound.enabled}
                 onCheckedChange={(enabled) => onChange(normalizeInbound({ ...inbound, enabled }))}
-                className="p-4 rounded-lg bg-gray-100 dark:bg-[#2b2b40]"
+                className="p-4 rounded-lg bg-ui-surface-muted"
             />
             <SettingInputVertical
                 label="Name"
@@ -734,7 +734,7 @@ const InboundModal: FC<{
             <ModalContent className="max-w-[900px]">
                 <ModalHeader closeButton className="border-b-0 pb-0">
                     <ModalTitle className="flex min-w-0 items-center gap-3 font-bold">
-                        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue-600/10 text-blue-600">
+                        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue-600/10 text-ui-primary">
                             <DoorOpen size={18} />
                         </span>
                         <span className="min-w-0 truncate">{title}</span>
@@ -783,7 +783,7 @@ const InboundItem: FC<{ item: Inbound }> = ({ item }) => {
         <>
             <div className="grid min-w-0 flex-1 gap-3 md:grid-cols-[minmax(180px,0.38fr)_minmax(0,1fr)] md:items-center">
                 <div className="flex min-w-0 items-center">
-                    <div className="mr-4 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue-600/10 text-blue-600">
+                    <div className="mr-4 flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-blue-600/10 text-ui-primary">
                         <LogIn size={20} />
                     </div>
                     <div className="flex min-w-0 flex-wrap items-center gap-2">
@@ -812,7 +812,7 @@ const InboundItem: FC<{ item: Inbound }> = ({ item }) => {
                     </div>
                 </div>
             </div>
-            <ChevronRight className="text-gray-500 opacity-25" size={16} />
+            <ChevronRight className="text-ui-muted opacity-25" size={16} />
         </>
     );
 };
@@ -854,7 +854,7 @@ const InboundConfigCard: FC = () => {
     return (
         <Card className="mb-4">
             <CardHeader>
-                <IconBox icon={Settings} color="#0d6efd" title="Inbound Configuration" description="DNS interception and traffic inspection" />
+                <IconBox icon={Settings} tone="primary" title="Inbound Configuration" description="DNS interception and traffic inspection" />
                 <Button disabled={saving || isLoading || Boolean(apiError)} onClick={handleSave}>
                     {saving ? <Spinner size="sm" /> : <><Save className="mr-1" size={16} /> Apply Settings</>}
                 </Button>
@@ -958,7 +958,7 @@ export default function InboudComponent() {
                 onClickItem={(item) => setShowdata({ show: true, id: item.id, new: false })}
                 header={
                     <div className="flex w-full items-center justify-between gap-3">
-                        <IconBox icon={DoorOpen} color="#0d6efd" title="Entry Points" description={`${data.page.total} inbounds`} />
+                        <IconBox icon={DoorOpen} tone="primary" title="Entry Points" description={`${data.page.total} inbounds`} />
                         <Button size="sm" onClick={() => handleCreate(newInboundID())}>
                             <Plus className="mr-1" size={16} /> Add
                         </Button>

--- a/src/docs/login/page.tsx
+++ b/src/docs/login/page.tsx
@@ -26,7 +26,7 @@ export default function LoginPage() {
     };
 
     return (
-        <div className="flex items-center justify-center min-h-screen bg-[var(--bs-body-bg)] p-4">
+        <div className="flex items-center justify-center min-h-screen bg-ui-bg p-4">
             <Card className="w-full max-w-md !mb-0 shadow-xl">
                 <CardHeader>
                     <CardTitle className="text-xl">
@@ -37,9 +37,9 @@ export default function LoginPage() {
                 <form onSubmit={handleLogin}>
                     <CardBody className="space-y-4">
                         <div className="space-y-2">
-                            <label className="text-sm font-medium text-gray-500 dark:text-gray-400">{t('username')}</label>
+                            <label className="text-sm font-medium text-ui-muted">{t('username')}</label>
                             <div className="relative">
-                                <User className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
+                                <User className="absolute left-3 top-1/2 -translate-y-1/2 text-ui-muted" size={18} />
                                 <Input
                                     className="pl-10"
                                     placeholder={t('usernamePlaceholder')}
@@ -50,9 +50,9 @@ export default function LoginPage() {
                             </div>
                         </div>
                         <div className="space-y-2">
-                            <label className="text-sm font-medium text-gray-500 dark:text-gray-400">{t('password')}</label>
+                            <label className="text-sm font-medium text-ui-muted">{t('password')}</label>
                             <div className="relative">
-                                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
+                                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 text-ui-muted" size={18} />
                                 <Input
                                     type="password"
                                     className="pl-10"

--- a/src/docs/node/modal.tsx
+++ b/src/docs/node/modal.tsx
@@ -362,7 +362,7 @@ const NodeProtocolChain: FC<{
         <div className="mb-3">
             <div className="mb-2 flex items-center justify-between px-1">
                 <h6 className="mb-0 font-bold opacity-75">Protocol Chain</h6>
-                <small className="text-gray-500 dark:text-gray-400">{normalizedChain.length} steps</small>
+                <small className="text-ui-muted">{normalizedChain.length} steps</small>
             </div>
 
             <Accordion type="multiple" defaultValue={normalizedChain.length > 0 ? ["item-0"] : []} className="mb-3">
@@ -405,7 +405,7 @@ const NodeProtocolChain: FC<{
             </Accordion>
 
             {editable && (
-                <div className="flex flex-wrap items-end gap-3 rounded-ui-lg bg-gray-100 p-3 dark:bg-[#2b2b40] sm:flex-nowrap">
+                <div className="flex flex-wrap items-end gap-3 rounded-ui-lg bg-ui-surface-muted p-3 sm:flex-nowrap">
                     <div className="w-full flex-1">
                         <label className="mb-2 block text-sm font-bold opacity-75">New Protocol Step</label>
                         <Select
@@ -735,7 +735,7 @@ const AddressList: FC<{
         <div>
             <div className="mb-2 flex items-center justify-between px-1">
                 <h6 className="mb-0 font-bold opacity-75">{title}</h6>
-                <small className="text-gray-500 dark:text-gray-400">{items.length} entries</small>
+                <small className="text-ui-muted">{items.length} entries</small>
             </div>
 
             <Accordion type="multiple" defaultValue={items.length > 0 ? [`${title}-0`] : []} className="mb-3">
@@ -873,7 +873,7 @@ const WireguardForm: FC<{
             <div>
                 <div className="mb-2 flex items-center justify-between px-1">
                     <h6 className="mb-0 font-bold opacity-75">Peers</h6>
-                    <small className="text-gray-500 dark:text-gray-400">{peers.length} peers</small>
+                    <small className="text-ui-muted">{peers.length} peers</small>
                 </div>
 
                 <Accordion type="multiple" defaultValue={peers.length > 0 ? ["peer-0"] : []} className="mb-3">
@@ -981,7 +981,7 @@ const ServerTLSForm: FC<{
             <div>
                 <div className="mb-2 flex items-center justify-between px-1">
                     <h6 className="mb-0 font-bold opacity-75">Certificates</h6>
-                    <small className="text-gray-500 dark:text-gray-400">{certificates.length} entries</small>
+                    <small className="text-ui-muted">{certificates.length} entries</small>
                 </div>
                 <Accordion type="multiple" defaultValue={certificates.length > 0 ? ["cert-0"] : []} className="mb-3">
                     {certificates.map((cert, index) => (
@@ -1018,7 +1018,7 @@ const ServerTLSForm: FC<{
             <div>
                 <div className="mb-2 flex items-center justify-between px-1">
                     <h6 className="mb-0 font-bold opacity-75">SNI Certificates</h6>
-                    <small className="text-gray-500 dark:text-gray-400">{Object.keys(sni).length} entries</small>
+                    <small className="text-ui-muted">{Object.keys(sni).length} entries</small>
                 </div>
                 <Accordion type="multiple" className="mb-3">
                     {Object.entries(sni).map(([serverName, cert]) => (
@@ -1052,7 +1052,7 @@ const ServerTLSForm: FC<{
                     ))}
                 </Accordion>
                 {editable && (
-                    <div className="flex flex-wrap items-end gap-3 rounded-ui-lg bg-gray-100 p-3 dark:bg-[#2b2b40] sm:flex-nowrap">
+                    <div className="flex flex-wrap items-end gap-3 rounded-ui-lg bg-ui-surface-muted p-3 sm:flex-nowrap">
                         <div className="w-full flex-1">
                             <SettingInputVertical label="New SNI Hostname" value={newSNI} onChange={setNewSNI} />
                         </div>
@@ -1090,7 +1090,7 @@ const HTTPTerminationForm: FC<{
         <div>
             <div className="mb-2 flex items-center justify-between px-1">
                 <h6 className="mb-0 font-bold opacity-75">HTTP Headers</h6>
-                <small className="text-gray-500 dark:text-gray-400">{Object.keys(headers).length} paths</small>
+                <small className="text-ui-muted">{Object.keys(headers).length} paths</small>
             </div>
             <Accordion type="multiple" className="mb-3">
                 {Object.entries(headers).map(([path, value]) => {
@@ -1135,7 +1135,7 @@ const HTTPTerminationForm: FC<{
                 })}
             </Accordion>
             {editable && (
-                <div className="flex flex-wrap items-end gap-3 rounded-ui-lg bg-gray-100 p-3 dark:bg-[#2b2b40] sm:flex-nowrap">
+                <div className="flex flex-wrap items-end gap-3 rounded-ui-lg bg-ui-surface-muted p-3 sm:flex-nowrap">
                     <div className="w-full flex-1">
                         <SettingInputVertical label="New Path" value={newPath} onChange={setNewPath} />
                     </div>

--- a/src/docs/webui/page.tsx
+++ b/src/docs/webui/page.tsx
@@ -2,24 +2,32 @@
 
 import { useTheme } from '@/common/ThemeProvider';
 import type { ThemePreference } from '@/common/theme';
+import { Button } from '@/component/v2/button';
 import { Card, CardBody, CardHeader, IconBox, MainContainer, SettingLabel } from '@/component/v2/card';
 import { SettingInputVertical, SwitchCard } from "@/component/v2/forms";
+import { Input } from '@/component/v2/input';
 import { Select } from '@/component/v2/select';
 import { useLanguage } from '@/i18n/LanguageProvider';
 import { languageOptions } from '@/i18n/languages';
-import { Gauge, Globe, Info, Languages, Link, MapPin, Network, Palette, Radio, Shield, Terminal } from 'lucide-react';
-import React from "react";
+import clsx from 'clsx';
+import { Check, Gauge, Globe, Info, Languages, Link, MapPin, Network, Palette, Plus, Radio, Shield, Terminal, Trash } from 'lucide-react';
+import React, { useEffect, useMemo, useState } from "react";
 import { useTranslation } from 'react-i18next';
+import { mutate } from 'swr';
 import { useLocalStorage } from "usehooks-ts";
 import {
-    APIUrlDefault, APIUrlKey,
+    APIUrlDefault,
+    APIUrlKey,
+    APIUrlListKey,
     LatencyDNSUrlDefault, LatencyDNSUrlKey,
     LatencyHTTPUrlDefault, LatencyHTTPUrlKey,
     LatencyIPUrlDefault, LatencyIPUrlKey,
     LatencyIPv6Default, LatencyIPv6Key,
     LatencyStunTCPUrlDefault, LatencyStunTCPUrlKey,
     LatencyStunUrlDefault, LatencyStunUrlKey,
-    normalizeLatencyDNSUrl
+    normalizeApiUrl,
+    normalizeLatencyDNSUrl,
+    uniqueApiUrls,
 } from "../../common/apiurl";
 
 // Internal helper for this page to add icons to inputs
@@ -45,11 +53,206 @@ const InputWithIcon: React.FC<{
     </div>
 );
 
+function displayApiHost(url: string, sameOriginLabel: string) {
+    return url ? url : sameOriginLabel;
+}
+
+function ApiHostsCard() {
+    const { t } = useTranslation('webui');
+    const [url, setUrl] = useLocalStorage(APIUrlKey, APIUrlDefault);
+    const [hosts, setHosts] = useLocalStorage<string[]>(APIUrlListKey, []);
+    const [draft, setDraft] = useState("");
+
+    const active = normalizeApiUrl(url);
+    const savedHosts = useMemo(
+        () => uniqueApiUrls([active, ...(Array.isArray(hosts) ? hosts : [])]),
+        [active, hosts],
+    );
+
+    useEffect(() => {
+        const next = uniqueApiUrls([active, ...(Array.isArray(hosts) ? hosts : [])]);
+        const same =
+            next.length === (Array.isArray(hosts) ? hosts.length : 0) &&
+            next.every((item, index) => item === (hosts?.[index] ?? undefined));
+        if (!same) setHosts(next);
+    }, [active, hosts, setHosts]);
+
+    const refreshClients = async () => {
+        await mutate(() => true, undefined, { revalidate: true });
+    };
+
+    const selectHost = async (next: string) => {
+        const normalized = normalizeApiUrl(next);
+        if (normalized === active) return;
+        setUrl(normalized);
+        setHosts(uniqueApiUrls([normalized, ...savedHosts]));
+        await refreshClients();
+    };
+
+    const addHost = async () => {
+        const normalized = normalizeApiUrl(draft);
+        if (!normalized) return;
+        const nextHosts = uniqueApiUrls([normalized, ...savedHosts]);
+        setHosts(nextHosts);
+        setDraft("");
+        if (normalized !== active) {
+            setUrl(normalized);
+            await refreshClients();
+        }
+    };
+
+    const removeHost = async (target: string) => {
+        const normalized = normalizeApiUrl(target);
+        if (!normalized) return;
+        const nextHosts = savedHosts.filter((item) => item !== normalized);
+        setHosts(nextHosts);
+        if (normalized === active) {
+            const fallback = nextHosts[0] ?? "";
+            setUrl(fallback);
+            await refreshClients();
+        }
+    };
+
+    return (
+        <Card>
+            <CardHeader className="py-3">
+                <IconBox icon={Link} tone="violet" title={t('api.title')} description={t('api.description')} />
+            </CardHeader>
+            <CardBody className="pt-2">
+                <div className="mb-3 flex items-center justify-between gap-3">
+                    <SettingLabel className="mb-0">{t('api.controllerHost')}</SettingLabel>
+                    <span className="text-xs text-ui-muted">
+                        {savedHosts.filter(Boolean).length} {t('api.saved')}
+                    </span>
+                </div>
+
+                <div className="flex flex-col gap-2">
+                    {/* Always-available same-origin option */}
+                    <button
+                        type="button"
+                        onClick={() => void selectHost("")}
+                        className={clsx(
+                            "flex w-full items-center gap-3 rounded-ui-lg border px-3 py-3 text-left transition-colors",
+                            active === ""
+                                ? "border-ui-primary/40 bg-ui-primary-soft/50"
+                                : "border-ui-border bg-ui-surface hover:border-ui-primary/25 hover:bg-ui-surface-muted/50"
+                        )}
+                    >
+                        <div className={clsx(
+                            "flex h-9 w-9 shrink-0 items-center justify-center rounded-ui-md border",
+                            active === ""
+                                ? "border-ui-primary/20 bg-ui-primary-soft text-ui-primary"
+                                : "border-ui-border bg-ui-surface-muted text-ui-muted"
+                        )}>
+                            <Network size={16} />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                            <div className="truncate text-sm font-semibold text-ui-heading">
+                                {t('api.sameOrigin')}
+                            </div>
+                            <div className="mt-0.5 truncate font-mono text-[11px] text-ui-muted">
+                                {typeof window !== "undefined" ? window.location.origin : "/"}
+                            </div>
+                        </div>
+                        {active === "" && (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-ui-primary-soft px-2 py-0.5 text-[11px] font-semibold text-ui-primary">
+                                <Check size={12} />
+                                {t('api.active')}
+                            </span>
+                        )}
+                    </button>
+
+                    {savedHosts.filter(Boolean).map((host) => {
+                        const isActive = host === active;
+                        return (
+                            <div
+                                key={host}
+                                className={clsx(
+                                    "flex w-full items-center gap-2 rounded-ui-lg border px-2 py-2 transition-colors",
+                                    isActive
+                                        ? "border-ui-primary/40 bg-ui-primary-soft/50"
+                                        : "border-ui-border bg-ui-surface hover:border-ui-primary/25 hover:bg-ui-surface-muted/50"
+                                )}
+                            >
+                                <button
+                                    type="button"
+                                    onClick={() => void selectHost(host)}
+                                    className="flex min-w-0 flex-1 items-center gap-3 rounded-ui-md px-1 py-1 text-left"
+                                >
+                                    <div className={clsx(
+                                        "flex h-9 w-9 shrink-0 items-center justify-center rounded-ui-md border",
+                                        isActive
+                                            ? "border-ui-primary/20 bg-ui-primary-soft text-ui-primary"
+                                            : "border-ui-border bg-ui-surface-muted text-ui-muted"
+                                    )}>
+                                        <Link size={16} />
+                                    </div>
+                                    <div className="min-w-0 flex-1">
+                                        <div className="truncate font-mono text-sm font-semibold text-ui-heading" title={host}>
+                                            {displayApiHost(host, t('api.sameOrigin'))}
+                                        </div>
+                                        <div className="mt-0.5 text-[11px] text-ui-muted">
+                                            {isActive ? t('api.activeHint') : t('api.switchHint')}
+                                        </div>
+                                    </div>
+                                    {isActive && (
+                                        <span className="inline-flex items-center gap-1 rounded-full bg-ui-primary-soft px-2 py-0.5 text-[11px] font-semibold text-ui-primary">
+                                            <Check size={12} />
+                                            {t('api.active')}
+                                        </span>
+                                    )}
+                                </button>
+                                <Button
+                                    size="icon"
+                                    variant="outline-danger"
+                                    className="h-9 w-9 shrink-0"
+                                    onClick={() => void removeHost(host)}
+                                    aria-label={t('api.remove')}
+                                    title={t('api.remove')}
+                                >
+                                    <Trash size={15} />
+                                </Button>
+                            </div>
+                        );
+                    })}
+                </div>
+
+                <div className="mt-4 border-t border-ui-border/70 pt-4">
+                    <SettingLabel className="mb-2">{t('api.addHost')}</SettingLabel>
+                    <div className="flex flex-col gap-2 sm:flex-row">
+                        <Input
+                            value={draft}
+                            onChange={(e) => setDraft(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === "Enter") {
+                                    e.preventDefault();
+                                    void addHost();
+                                }
+                            }}
+                            placeholder="http://127.0.0.1:50051"
+                            className="min-w-0 flex-1 font-mono"
+                        />
+                        <Button
+                            size="sm"
+                            className="shrink-0"
+                            disabled={!normalizeApiUrl(draft)}
+                            onClick={() => void addHost()}
+                        >
+                            <Plus size={16} className="mr-1" />
+                            {t('api.add')}
+                        </Button>
+                    </div>
+                    <p className="mt-2 text-xs text-ui-muted">{t('api.addHint')}</p>
+                </div>
+            </CardBody>
+        </Card>
+    );
+}
+
 function Setting() {
     const { t } = useTranslation('webui');
     const { preference, setPreference } = useLanguage();
     const { preference: themePreference, setPreference: setThemePreference } = useTheme();
-    const [url, setUrl] = useLocalStorage(APIUrlKey, APIUrlDefault);
     const [latencyHTTP, setLatencyHTTP] = useLocalStorage(LatencyHTTPUrlKey, LatencyHTTPUrlDefault);
     const [latencyDNS, setLatencyDNS] = useLocalStorage(LatencyDNSUrlKey, LatencyDNSUrlDefault);
     const [latencyIPv6, setLatencyIPv6] = useLocalStorage(LatencyIPv6Key, LatencyIPv6Default);
@@ -60,20 +263,7 @@ function Setting() {
     return (
         <MainContainer>
             {/* 1. API Connection */}
-            <Card>
-                <CardHeader className="py-3">
-                    <IconBox icon={Link} tone="violet" title={t('api.title')} description={t('api.description')} />
-                </CardHeader>
-                <CardBody className="pt-2">
-                    <InputWithIcon
-                        icon={Network}
-                        label={t('api.controllerHost')}
-                        value={url}
-                        onChange={setUrl}
-                        placeholder="http://127.0.0.1:50051"
-                    />
-                </CardBody>
-            </Card>
+            <ApiHostsCard />
 
             <Card>
                 <CardHeader className="py-3">

--- a/src/docs/webui/page.tsx
+++ b/src/docs/webui/page.tsx
@@ -1,11 +1,13 @@
 "use client"
 
+import { useTheme } from '@/common/ThemeProvider';
+import type { ThemePreference } from '@/common/theme';
 import { Card, CardBody, CardHeader, IconBox, MainContainer, SettingLabel } from '@/component/v2/card';
 import { SettingInputVertical, SwitchCard } from "@/component/v2/forms";
 import { Select } from '@/component/v2/select';
 import { useLanguage } from '@/i18n/LanguageProvider';
 import { languageOptions } from '@/i18n/languages';
-import { Gauge, Globe, Info, Languages, Link, MapPin, Network, Radio, Shield, Terminal } from 'lucide-react';
+import { Gauge, Globe, Info, Languages, Link, MapPin, Network, Palette, Radio, Shield, Terminal } from 'lucide-react';
 import React from "react";
 import { useTranslation } from 'react-i18next';
 import { useLocalStorage } from "usehooks-ts";
@@ -15,9 +17,9 @@ import {
     LatencyHTTPUrlDefault, LatencyHTTPUrlKey,
     LatencyIPUrlDefault, LatencyIPUrlKey,
     LatencyIPv6Default, LatencyIPv6Key,
-    normalizeLatencyDNSUrl,
     LatencyStunTCPUrlDefault, LatencyStunTCPUrlKey,
-    LatencyStunUrlDefault, LatencyStunUrlKey
+    LatencyStunUrlDefault, LatencyStunUrlKey,
+    normalizeLatencyDNSUrl
 } from "../../common/apiurl";
 
 // Internal helper for this page to add icons to inputs
@@ -29,8 +31,8 @@ const InputWithIcon: React.FC<{
     placeholder: string;
 }> = ({ icon: Icon, label, value, onChange, placeholder }) => (
     <div className="flex items-start gap-3 mb-4">
-        <div className="bg-gray-500/10 rounded-lg p-2 mt-4 hidden sm:block border border-gray-500/10">
-            <span className="text-gray-500 dark:text-gray-400 text-lg flex"><Icon /></span>
+        <div className="bg-ui-surface-muted rounded-ui-md p-2 mt-4 hidden sm:block border border-ui-border">
+            <span className="text-ui-muted text-lg flex"><Icon /></span>
         </div>
         <div className="flex-grow">
             <SettingInputVertical
@@ -46,6 +48,7 @@ const InputWithIcon: React.FC<{
 function Setting() {
     const { t } = useTranslation('webui');
     const { preference, setPreference } = useLanguage();
+    const { preference: themePreference, setPreference: setThemePreference } = useTheme();
     const [url, setUrl] = useLocalStorage(APIUrlKey, APIUrlDefault);
     const [latencyHTTP, setLatencyHTTP] = useLocalStorage(LatencyHTTPUrlKey, LatencyHTTPUrlDefault);
     const [latencyDNS, setLatencyDNS] = useLocalStorage(LatencyDNSUrlKey, LatencyDNSUrlDefault);
@@ -59,7 +62,7 @@ function Setting() {
             {/* 1. API Connection */}
             <Card>
                 <CardHeader className="py-3">
-                    <IconBox icon={Link} color="#6366f1" title={t('api.title')} description={t('api.description')} />
+                    <IconBox icon={Link} tone="violet" title={t('api.title')} description={t('api.description')} />
                 </CardHeader>
                 <CardBody className="pt-2">
                     <InputWithIcon
@@ -74,7 +77,7 @@ function Setting() {
 
             <Card>
                 <CardHeader className="py-3">
-                    <IconBox icon={Languages} color="#8b5cf6" title={t('language.title')} description={t('language.description')} />
+                    <IconBox icon={Languages} tone="violet" title={t('language.title')} description={t('language.description')} />
                 </CardHeader>
                 <CardBody className="pt-2">
                     <div className="flex flex-col mb-4">
@@ -91,10 +94,30 @@ function Setting() {
                 </CardBody>
             </Card>
 
+            <Card>
+                <CardHeader className="py-3">
+                    <IconBox icon={Palette} tone="primary" title={t('theme.title')} description={t('theme.description')} />
+                </CardHeader>
+                <CardBody className="pt-2">
+                    <div className="flex flex-col mb-4">
+                        <SettingLabel className="mb-2 block">{t('theme.preference')}</SettingLabel>
+                        <Select
+                            value={themePreference}
+                            onValueChange={(value) => setThemePreference(value as ThemePreference)}
+                            items={[
+                                { value: "system", label: t('theme.system') },
+                                { value: "light", label: t('theme.light') },
+                                { value: "dark", label: t('theme.dark') },
+                            ]}
+                        />
+                    </div>
+                </CardBody>
+            </Card>
+
             {/* 2. Latency Targets */}
             <Card >
                 <CardHeader className="py-3">
-                    <IconBox icon={Gauge} color="#10b981" title={t('latency.title')} description={t('latency.description')} />
+                    <IconBox icon={Gauge} tone="success" title={t('latency.title')} description={t('latency.description')} />
                 </CardHeader>
                 <CardBody>
                     {/* Toggle at the top */}
@@ -147,7 +170,7 @@ function Setting() {
             </Card>
 
             <div className="text-center mt-3 opacity-50 pb-20">
-                <small className="text-gray-500 dark:text-gray-400 flex items-center justify-center">
+                <small className="text-ui-muted flex items-center justify-center">
                     <Info className="mr-1" />
                     {t('localNotice')}
                 </small>

--- a/src/global.css
+++ b/src/global.css
@@ -25,7 +25,7 @@
     --bs-gray-700: #495057;
     --bs-gray-800: #343a40;
     --bs-gray-900: #212529;
-    --bs-primary: #0d6efd;
+    --bs-primary: #0284c7;
     --bs-secondary: #6c757d;
     --bs-success: #198754;
     --bs-info: #0dcaf0;
@@ -33,7 +33,7 @@
     --bs-danger: #dc3545;
     --bs-light: #f8f9fa;
     --bs-dark: #212529;
-    --bs-primary-rgb: 13, 110, 253;
+    --bs-primary-rgb: 2, 132, 199;
     --bs-secondary-rgb: 108, 117, 125;
     --bs-success-rgb: 25, 135, 84;
     --bs-info-rgb: 13, 202, 240;
@@ -89,11 +89,11 @@
     --bs-tertiary-bg: #f8f9fa;
     --bs-tertiary-bg-rgb: 248, 249, 250;
     --bs-heading-color: inherit;
-    --bs-link-color: #0d6efd;
-    --bs-link-color-rgb: 13, 110, 253;
+    --bs-link-color: #0284c7;
+    --bs-link-color-rgb: 2, 132, 199;
     --bs-link-decoration: underline;
-    --bs-link-hover-color: #0a58ca;
-    --bs-link-hover-color-rgb: 10, 88, 202;
+    --bs-link-hover-color: #0369a1;
+    --bs-link-hover-color-rgb: 3, 105, 161;
     --bs-code-color: #d63384;
     --bs-highlight-color: #212529;
     --bs-highlight-bg: #fff3cd;
@@ -155,7 +155,9 @@ html[data-bs-theme="dark"] {
     --bs-tertiary-color-rgb: 228, 231, 236;
     --bs-tertiary-bg: #202329;
     --bs-tertiary-bg-rgb: 32, 35, 41;
-    --bs-primary-text-emphasis: #9bc2e6;
+    --bs-primary: #0ea5e9;
+    --bs-primary-rgb: 14, 165, 233;
+    --bs-primary-text-emphasis: #7dd3fc;
     --bs-secondary-text-emphasis: #aab1bd;
     --bs-success-text-emphasis: #8fc7a8;
     --bs-info-text-emphasis: #8ecbd6;
@@ -163,7 +165,7 @@ html[data-bs-theme="dark"] {
     --bs-danger-text-emphasis: #ef9aa2;
     --bs-light-text-emphasis: #f5f7fa;
     --bs-dark-text-emphasis: #d7dce4;
-    --bs-primary-bg-subtle: rgba(116, 161, 202, 0.14);
+    --bs-primary-bg-subtle: rgba(14, 165, 233, 0.14);
     --bs-secondary-bg-subtle: #1d2026;
     --bs-success-bg-subtle: rgba(143, 199, 168, 0.12);
     --bs-info-bg-subtle: rgba(142, 203, 214, 0.12);
@@ -171,7 +173,7 @@ html[data-bs-theme="dark"] {
     --bs-danger-bg-subtle: rgba(239, 154, 162, 0.12);
     --bs-light-bg-subtle: #2b3038;
     --bs-dark-bg-subtle: #15171b;
-    --bs-primary-border-subtle: rgba(116, 161, 202, 0.36);
+    --bs-primary-border-subtle: rgba(14, 165, 233, 0.36);
     --bs-secondary-border-subtle: #3a404a;
     --bs-success-border-subtle: rgba(143, 199, 168, 0.32);
     --bs-info-border-subtle: rgba(142, 203, 214, 0.32);
@@ -180,10 +182,10 @@ html[data-bs-theme="dark"] {
     --bs-light-border-subtle: #424954;
     --bs-dark-border-subtle: #303640;
     --bs-heading-color: inherit;
-    --bs-link-color: #9bc2e6;
-    --bs-link-hover-color: #b4d2ef;
-    --bs-link-color-rgb: 155, 194, 230;
-    --bs-link-hover-color-rgb: 180, 210, 239;
+    --bs-link-color: #7dd3fc;
+    --bs-link-hover-color: #bae6fd;
+    --bs-link-color-rgb: 125, 211, 252;
+    --bs-link-hover-color-rgb: 186, 230, 253;
     --bs-code-color: #dda0bc;
     --bs-highlight-color: #e4e7ec;
     --bs-highlight-bg: rgba(229, 189, 117, 0.22);
@@ -206,8 +208,8 @@ html[data-bs-theme="dark"] {
 
     --sidebar-hover-bg: #22262d;
 
-    --sidebar-active-bg: rgba(116, 161, 202, 0.14);
-    --sidebar-active-color: #9bc2e6;
+    --sidebar-active-bg: rgba(14, 165, 233, 0.14);
+    --sidebar-active-color: #7dd3fc;
     --sidebar-active-glow: none;
 
     --sidebar-box-shadow: 0 18px 40px -18px rgba(0, 0, 0, 0.72);
@@ -248,9 +250,9 @@ html[data-bs-theme="dark"] {
     --color-list-row-border-hover: var(--list-item-border-hover);
     --color-border: #343a44;
     --color-hover: #22262d;
-    /* Keep filled buttons dark enough for white text in dark mode. */
-    --color-primary: #2563eb;
-    --color-primary-soft: rgba(116, 161, 202, 0.14);
+    /* Sky family — same hue as light; filled buttons keep white-text contrast. */
+    --color-primary: #0ea5e9;
+    --color-primary-soft: rgba(14, 165, 233, 0.14);
     --color-danger: #ef9aa2;
     --color-danger-soft: rgba(239, 154, 162, 0.12);
     --color-success: #8fc7a8;
@@ -261,7 +263,9 @@ html[data-bs-theme="dark"] {
     --color-info-soft: rgba(142, 203, 214, 0.12);
     --color-chip: #262a31;
     --color-chip-fg: #aab1bd;
-    --color-focus: rgba(155, 194, 230, 0.28);
+    --color-focus: rgba(14, 165, 233, 0.32);
+    --color-violet: #a78bfa;
+    --color-violet-soft: rgba(167, 139, 250, 0.14);
     --shadow-card: 0 18px 40px -20px rgba(0, 0, 0, 0.72);
     --shadow-elevated: 0 20px 48px -24px rgba(0, 0, 0, 0.78);
     --shadow-focus: 0 0 0 3px var(--color-focus);
@@ -337,9 +341,22 @@ html[data-bs-theme="light"] {
     --color-chip: #f1f5f9;
     --color-chip-fg: #64748b;
     --color-focus: rgba(2, 132, 199, 0.25);
+    --color-violet: #7c3aed;
+    --color-violet-soft: rgba(124, 58, 237, 0.12);
     --shadow-card: 0 20px 40px -10px rgba(0, 0, 0, 0.1);
-    --shadow-elevated: 0 0 30px rgba(99, 102, 241, 0.1);
+    --shadow-elevated: 0 20px 40px -12px rgba(2, 132, 199, 0.12);
     --shadow-focus: 0 0 0 3px var(--color-focus);
+
+    /* Keep Bootstrap primary in sync with ui primary (light). */
+    --bs-primary: #0284c7;
+    --bs-primary-rgb: 2, 132, 199;
+    --bs-link-color: #0284c7;
+    --bs-link-hover-color: #0369a1;
+    --bs-link-color-rgb: 2, 132, 199;
+    --bs-link-hover-color-rgb: 3, 105, 161;
+    --bs-primary-bg-subtle: #e0f2fe;
+    --bs-primary-border-subtle: #7dd3fc;
+    --bs-primary-text-emphasis: #0c4a6e;
 }
 
 /* 1. Basic Setup */
@@ -352,7 +369,12 @@ html[data-bs-theme="light"] {
         line-height: 1.5;
     }
 
-    h1, h2, h3, h4, h5, h6 {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
         margin-top: 0;
         margin-bottom: 0.5rem;
         font-weight: 500;
@@ -360,12 +382,29 @@ html[data-bs-theme="light"] {
         color: var(--bs-heading-color);
     }
 
-    h1 { font-size: 2.5rem; }
-    h2 { font-size: 2rem; }
-    h3 { font-size: 1.75rem; }
-    h4 { font-size: 1.5rem; }
-    h5 { font-size: 1.25rem; }
-    h6 { font-size: 1rem; }
+    h1 {
+        font-size: 2.5rem;
+    }
+
+    h2 {
+        font-size: 2rem;
+    }
+
+    h3 {
+        font-size: 1.75rem;
+    }
+
+    h4 {
+        font-size: 1.5rem;
+    }
+
+    h5 {
+        font-size: 1.25rem;
+    }
+
+    h6 {
+        font-size: 1rem;
+    }
 
     small {
         font-size: 0.875em;
@@ -381,7 +420,10 @@ html[data-bs-theme="light"] {
     }
 
     @media (prefers-reduced-motion: reduce) {
-        *, ::before, ::after {
+
+        *,
+        ::before,
+        ::after {
             animation-duration: 0.01ms !important;
             animation-iteration-count: 1 !important;
             scroll-behavior: auto !important;

--- a/src/i18n/resources/en/webui.json
+++ b/src/i18n/resources/en/webui.json
@@ -20,5 +20,13 @@
     "description": "Automatically follow the browser or choose a fixed language",
     "preference": "Language Preference"
   },
+  "theme": {
+    "title": "Appearance",
+    "description": "Follow the system or choose a fixed color scheme",
+    "preference": "Theme Preference",
+    "system": "System",
+    "light": "Light",
+    "dark": "Dark"
+  },
   "localNotice": "These settings are stored locally in your browser cache."
 }

--- a/src/i18n/resources/en/webui.json
+++ b/src/i18n/resources/en/webui.json
@@ -2,7 +2,16 @@
   "api": {
     "title": "API Connection",
     "description": "Web-controller interface",
-    "controllerHost": "Controller Host"
+    "controllerHost": "Controller Hosts",
+    "sameOrigin": "Same origin",
+    "active": "Active",
+    "activeHint": "Currently connected",
+    "switchHint": "Click to switch",
+    "saved": "saved",
+    "addHost": "Add host",
+    "add": "Add",
+    "addHint": "Save multiple controller addresses and switch between them anytime.",
+    "remove": "Remove host"
   },
   "latency": {
     "title": "Latency Targets",

--- a/src/i18n/resources/ja/webui.json
+++ b/src/i18n/resources/ja/webui.json
@@ -20,5 +20,13 @@
     "description": "ブラウザーに自動追従するか、固定言語を選択します",
     "preference": "言語設定"
   },
+  "theme": {
+    "title": "外観",
+    "description": "システムに合わせるか、固定の配色を選択します",
+    "preference": "テーマ設定",
+    "system": "システム",
+    "light": "ライト",
+    "dark": "ダーク"
+  },
   "localNotice": "これらの設定はブラウザーのローカルキャッシュに保存されます。"
 }

--- a/src/i18n/resources/ja/webui.json
+++ b/src/i18n/resources/ja/webui.json
@@ -2,7 +2,16 @@
   "api": {
     "title": "API 接続",
     "description": "Web コントローラーインターフェイス",
-    "controllerHost": "コントローラーホスト"
+    "controllerHost": "コントローラーホスト",
+    "sameOrigin": "同一オリジン",
+    "active": "使用中",
+    "activeHint": "現在接続中",
+    "switchHint": "クリックして切り替え",
+    "saved": "件保存済み",
+    "addHost": "ホストを追加",
+    "add": "追加",
+    "addHint": "複数のコントローラーアドレスを保存し、いつでも切り替えられます。",
+    "remove": "ホストを削除"
   },
   "latency": {
     "title": "遅延測定ターゲット",

--- a/src/i18n/resources/ko/webui.json
+++ b/src/i18n/resources/ko/webui.json
@@ -2,7 +2,16 @@
   "api": {
     "title": "API 연결",
     "description": "Web 컨트롤러 인터페이스",
-    "controllerHost": "컨트롤러 호스트"
+    "controllerHost": "컨트롤러 호스트",
+    "sameOrigin": "동일 출처",
+    "active": "사용 중",
+    "activeHint": "현재 연결됨",
+    "switchHint": "클릭하여 전환",
+    "saved": "개 저장됨",
+    "addHost": "호스트 추가",
+    "add": "추가",
+    "addHint": "여러 컨트롤러 주소를 저장하고 언제든지 전환할 수 있습니다.",
+    "remove": "호스트 삭제"
   },
   "latency": {
     "title": "지연 시간 대상",

--- a/src/i18n/resources/ko/webui.json
+++ b/src/i18n/resources/ko/webui.json
@@ -20,5 +20,13 @@
     "description": "브라우저를 자동으로 따르거나 고정 언어를 선택합니다",
     "preference": "언어 설정"
   },
+  "theme": {
+    "title": "모양",
+    "description": "시스템을 따르거나 고정 색 구성표를 선택합니다",
+    "preference": "테마 설정",
+    "system": "시스템",
+    "light": "라이트",
+    "dark": "다크"
+  },
   "localNotice": "이 설정은 브라우저 캐시에 로컬로 저장됩니다."
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { SWRConfig } from 'swr';
+import App from './App';
+import './global.css';
 import './i18n';
 import { LanguageProvider } from './i18n/LanguageProvider';
-import './global.css';
-import App from './App';
 
 // Render the app
 const rootElement = document.getElementById('root')!
@@ -11,9 +12,15 @@ if (!rootElement.innerHTML) {
     const root = createRoot(rootElement)
     root.render(
         <StrictMode>
-            <LanguageProvider>
-                <App />
-            </LanguageProvider>
+            <SWRConfig value={{
+                revalidateOnFocus: false,
+                dedupingInterval: 2000,
+                shouldRetryOnError: false,
+            }}>
+                <LanguageProvider>
+                    <App />
+                </LanguageProvider>
+            </SWRConfig>
         </StrictMode>,
     )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -78,13 +78,14 @@ module.exports = {
           'from': { height: 'var(--radix-collapsible-content-height)', opacity: '1' },
           'to': { height: '0', opacity: '0' },
         },
+        // Height-only: opacity during collapse composites as a bright flash on dark UI.
         'accordion-down': {
-          from: { height: '0', opacity: '0' },
-          to: { height: 'var(--radix-accordion-content-height)', opacity: '1' },
+          from: { height: '0' },
+          to: { height: 'var(--radix-accordion-content-height)' },
         },
         'accordion-up': {
-          from: { height: 'var(--radix-accordion-content-height)', opacity: '1' },
-          to: { height: '0', opacity: '0' },
+          from: { height: 'var(--radix-accordion-content-height)' },
+          to: { height: '0' },
         },
         slideUpAndFade: {
           from: { opacity: '0', transform: 'translateY(4px) scale(0.98)' },
@@ -122,8 +123,8 @@ module.exports = {
       animation: {
         slideDown: 'slideDown 0.3s ease-out',
         slideUp: 'slideUp 0.3s ease-out',
-        'accordion-down': 'accordion-down 0.3s ease-out',
-        'accordion-up': 'accordion-up 0.3s ease-out',
+        'accordion-down': 'accordion-down 0.3s ease-out forwards',
+        'accordion-up': 'accordion-up 0.3s ease-out forwards',
         slideUpAndFade: 'slideUpAndFade 0.25s cubic-bezier(0.16, 1, 0.3, 1)',
         slideDownAndFade: 'slideDownAndFade 0.25s cubic-bezier(0.16, 1, 0.3, 1)',
         slideLeftAndFade: 'slideLeftAndFade 400ms cubic-bezier(0.16, 1, 0.3, 1)',


### PR DESCRIPTION
Add theme support and shared ui tokens, redesign outbound node rows and home metrics, polish route rules, fix accordion collapse flash, and coerce RPC path index to numbers for Go uint32.